### PR TITLE
fix: Remove placeholder text and position cursor at top-left of page (#6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,6 @@ These IDs are referenced across HTML, CSS, and JS. Do not rename without updatin
 - `#text-display` — text rendering container
 - `#hidden-input` — hidden textarea for input capture
 - `#cursor` — blinking block cursor
-- `#placeholder` — "Just start typing…" placeholder
 - `#new-draft-dialog` — native `<dialog>` for new draft confirmation
 - `#btn-confirm-new` — confirm button in dialog
 - `#btn-cancel-new` — cancel button in dialog

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -188,16 +188,7 @@ body {
   -webkit-user-select: none;
 }
 
-.placeholder {
-  color: var(--ghost-color);
-  font-style: italic;
-  pointer-events: none;
-  transition: opacity 0.3s ease;
-}
 
-.placeholder.hidden {
-  opacity: 0;
-}
 
 .char {
   /* Base character - no special styling needed once settled */

--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,7 @@
         </div>
       </header>
       <div id="etype-screen">
-        <div id="text-display"><span id="placeholder" class="placeholder">Just start typing…</span><span id="cursor" class="cursor">█</span></div>
+        <div id="text-display"><span id="cursor" class="cursor">█</span></div>
       </div>
     </div>
   </div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19,7 +19,6 @@ function init() {
   const displayEl = document.getElementById('text-display');
   const inputEl = document.getElementById('hidden-input');
   const cursorEl = document.getElementById('cursor');
-  const placeholderEl = document.getElementById('placeholder');
   const screenEl = document.getElementById('etype-screen');
   const wordCountEl = document.getElementById('word-count');
   const titleInputEl = document.getElementById('title-input');
@@ -57,7 +56,7 @@ function init() {
   }, 1500);
   
   // ---- Initialize Typewriter ----
-  const typewriter = new Typewriter(displayEl, inputEl, cursorEl, placeholderEl, {
+  const typewriter = new Typewriter(displayEl, inputEl, cursorEl, {
     onTextChange: (text) => {
       ui.updateWordCount(text);
       autoSave();

--- a/public/js/typewriter.js
+++ b/public/js/typewriter.js
@@ -8,23 +8,21 @@ export class Typewriter {
    * @param {HTMLElement} displayEl - #text-display
    * @param {HTMLTextAreaElement} inputEl - #hidden-input
    * @param {HTMLElement} cursorEl - #cursor
-   * @param {HTMLElement} placeholderEl - #placeholder
    * @param {Object} options
    * @param {Function} options.onTextChange - callback(text) on every change
    * @param {Function} options.onFirstChar - callback() on first character typed
    */
-  constructor(displayEl, inputEl, cursorEl, placeholderEl, options = {}) {
+  constructor(displayEl, inputEl, cursorEl, options = {}) {
     this.displayEl = displayEl;
     this.inputEl = inputEl;
     this.cursorEl = cursorEl;
-    this.placeholderEl = placeholderEl;
     this.onTextChange = options.onTextChange || null;
     this.onFirstChar = options.onFirstChar || null;
     
     this.text = '';           // canonical text buffer (append-only during typing)
     this.queue = [];          // characters waiting to be rendered
     this.isProcessing = false;
-    this.hasTyped = false;    // tracks if user has typed anything (for placeholder)
+    this.hasTyped = false;
     
     this._bindEvents();
   }
@@ -168,12 +166,8 @@ export class Typewriter {
   }
   
   _renderChar(char) {
-    // Hide placeholder on first character
     if (!this.hasTyped) {
       this.hasTyped = true;
-      if (this.placeholderEl) {
-        this.placeholderEl.classList.add('hidden');
-      }
       if (this.onFirstChar) {
         this.onFirstChar();
       }
@@ -211,35 +205,20 @@ export class Typewriter {
     
     // Clear existing rendered characters (preserve cursor)
     const cursor = this.cursorEl;
-    const placeholder = this.placeholderEl;
     
     // Remove all children except cursor
     while (this.displayEl.firstChild) {
       if (this.displayEl.firstChild === cursor) break;
-      if (this.displayEl.firstChild === placeholder) {
-        this.displayEl.removeChild(placeholder);
-        continue;
-      }
       this.displayEl.removeChild(this.displayEl.firstChild);
     }
     
     // Insert restored text as a plain text node (no animation)
     if (text) {
       this.hasTyped = true;
-      if (placeholder && this.displayEl.contains(placeholder)) {
-        placeholder.classList.add('hidden');
-      }
       const textNode = document.createTextNode(text);
       this.displayEl.insertBefore(textNode, cursor);
     } else {
       this.hasTyped = false;
-      // Re-show placeholder if it exists
-      if (placeholder) {
-        placeholder.classList.remove('hidden');
-        if (!this.displayEl.contains(placeholder)) {
-          this.displayEl.insertBefore(placeholder, cursor);
-        }
-      }
     }
     
     this._forceCursorToEnd();
@@ -253,17 +232,11 @@ export class Typewriter {
     this.inputEl.value = '';
     this.hasTyped = false;
     
-    // Remove all children except cursor, then re-add placeholder
+    // Remove all children except cursor
     while (this.displayEl.firstChild) {
+      if (this.displayEl.firstChild === this.cursorEl) break;
       this.displayEl.removeChild(this.displayEl.firstChild);
     }
-    
-    // Re-add placeholder and cursor
-    if (this.placeholderEl) {
-      this.placeholderEl.classList.remove('hidden');
-      this.displayEl.appendChild(this.placeholderEl);
-    }
-    this.displayEl.appendChild(this.cursorEl);
     
     this._notifyChange();
   }


### PR DESCRIPTION
Closes #6

## Summary
- Removed the `#placeholder` element ("Just start typing...") from `public/index.html` so the e-paper viewport starts completely blank.
- Positioned the blinking block cursor (`#cursor`) at the top-left of `#text-display`.
- Updated `public/js/typewriter.js`, `public/js/app.js`, and `public/css/index.css` to remove placeholder logic and styling.
- Updated `AGENTS.md` DOM contract documentation.

## Verification
- Verified layout locally — page displays a clean, blank e-paper screen with the flashing cursor immediately at the top-left.