### PR TITLE
feat: Request Google Drive scope and manage 'etype_drafts' folder (#2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,8 @@ jobs:
               'public/js/typewriter.js',
               'public/js/storage.js',
               'public/js/ui.js',
-              'public/js/auth.js'
+              'public/js/auth.js',
+              'public/js/drive.js'
             ];
             files.forEach(f => {
               if (!fs.existsSync(f)) throw new Error('File does not exist: ' + f);

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,4 +1,4 @@
-// auth.js — Google Authentication via Firebase Auth SDK
+// auth.js — Google Authentication via Firebase Auth SDK & OAuth Scopes
 
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js';
 import { 
@@ -23,15 +23,24 @@ const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 
 const googleProvider = new GoogleAuthProvider();
+// Request Google Drive file scope for saving drafts to etype_drafts folder
+googleProvider.addScope('https://www.googleapis.com/auth/drive.file');
+
+let currentAccessToken = sessionStorage.getItem('etype_gdrive_token') || null;
 
 /**
  * Sign in with Google using popup.
- * @returns {Promise<import('https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js').User>}
+ * @returns {Promise<{user: import('https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js').User, accessToken: string|null}>}
  */
 export async function loginWithGoogle() {
   try {
     const result = await signInWithPopup(auth, googleProvider);
-    return result.user;
+    const credential = GoogleAuthProvider.credentialFromResult(result);
+    if (credential && credential.accessToken) {
+      currentAccessToken = credential.accessToken;
+      sessionStorage.setItem('etype_gdrive_token', currentAccessToken);
+    }
+    return { user: result.user, accessToken: currentAccessToken };
   } catch (error) {
     if (error.code !== 'auth/popup-closed-by-user') {
       console.error('E-Type Auth Error:', error);
@@ -41,12 +50,22 @@ export async function loginWithGoogle() {
 }
 
 /**
+ * Get current Google OAuth access token.
+ * @returns {string|null}
+ */
+export function getAccessToken() {
+  return currentAccessToken;
+}
+
+/**
  * Sign out current user.
  * @returns {Promise<void>}
  */
 export async function logout() {
   try {
     await signOut(auth);
+    currentAccessToken = null;
+    sessionStorage.removeItem('etype_gdrive_token');
   } catch (error) {
     console.error('E-Type Logout Error:', error);
     throw error;
@@ -59,5 +78,11 @@ export async function logout() {
  * @returns {Function} Unsubscribe function
  */
 export function onUserChanged(callback) {
-  return onAuthStateChanged(auth, callback);
+  return onAuthStateChanged(auth, (user) => {
+    if (!user) {
+      currentAccessToken = null;
+      sessionStorage.removeItem('etype_gdrive_token');
+    }
+    callback(user);
+  });
 }

--- a/public/js/drive.js
+++ b/public/js/drive.js
@@ -1,0 +1,120 @@
+// drive.js — Google Drive API integration for etype_drafts folder and uploads
+
+const DRIVE_API_BASE = 'https://www.googleapis.com/drive/v3';
+const UPLOAD_API_BASE = 'https://www.googleapis.com/upload/drive/v3';
+const FOLDER_NAME = 'etype_drafts';
+
+let cachedFolderId = null;
+
+/**
+ * Searches for the 'etype_drafts' folder in the user's Google Drive.
+ * Creates it if it does not exist.
+ * @param {string} accessToken - Google OAuth Access Token
+ * @returns {Promise<string>} Google Drive Folder ID
+ */
+export async function getOrCreateDraftsFolder(accessToken) {
+  if (cachedFolderId) return cachedFolderId;
+
+  if (!accessToken) {
+    throw new Error('No Google access token available. Please sign in with Google.');
+  }
+
+  // 1. Search for existing folder
+  const query = encodeURIComponent(`name = '${FOLDER_NAME}' and mimeType = 'application/vnd.google-apps.folder' and trashed = false`);
+  const searchUrl = `${DRIVE_API_BASE}/files?q=${query}&fields=files(id,name)`;
+
+  const response = await fetch(searchUrl, {
+    headers: {
+      'Authorization': `Bearer ${accessToken}`
+    }
+  });
+
+  if (!response.ok) {
+    const errText = await response.text();
+    throw new Error(`Google Drive API error (${response.status}): ${errText}`);
+  }
+
+  const data = await response.json();
+  if (data.files && data.files.length > 0) {
+    cachedFolderId = data.files[0].id;
+    return cachedFolderId;
+  }
+
+  // 2. Create the folder if missing
+  const createResponse = await fetch(`${DRIVE_API_BASE}/files`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      name: FOLDER_NAME,
+      mimeType: 'application/vnd.google-apps.folder'
+    })
+  });
+
+  if (!createResponse.ok) {
+    const errText = await createResponse.text();
+    throw new Error(`Failed to create '${FOLDER_NAME}' folder in Google Drive: ${errText}`);
+  }
+
+  const createdFolder = await createResponse.json();
+  cachedFolderId = createdFolder.id;
+  return cachedFolderId;
+}
+
+/**
+ * Saves a markdown draft to the 'etype_drafts' folder in Google Drive.
+ * @param {string} accessToken - Google OAuth Access Token
+ * @param {string} title - File title/name
+ * @param {string} content - Markdown draft content
+ * @returns {Promise<{id: string, name: string, webViewLink: string}>} Uploaded file details
+ */
+export async function saveDraftToDrive(accessToken, title, content) {
+  const folderId = await getOrCreateDraftsFolder(accessToken);
+  const filename = (title.trim() || 'Untitled Draft') + '.md';
+
+  const metadata = {
+    name: filename,
+    mimeType: 'text/markdown',
+    parents: [folderId]
+  };
+
+  const boundary = 'foo_bar_baz';
+  const delimiter = `\r\n--${boundary}\r\n`;
+  const closeDelimiter = `\r\n--${boundary}--`;
+
+  const multipartRequestBody =
+    delimiter +
+    'Content-Type: application/json; charset=UTF-8\r\n\r\n' +
+    JSON.stringify(metadata) +
+    delimiter +
+    'Content-Type: text/markdown; charset=UTF-8\r\n\r\n' +
+    content +
+    closeDelimiter;
+
+  const uploadUrl = `${UPLOAD_API_BASE}/files?uploadType=multipart&fields=id,name,webViewLink`;
+
+  const response = await fetch(uploadUrl, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': `multipart/related; boundary=${boundary}`
+    },
+    body: multipartRequestBody
+  });
+
+  if (!response.ok) {
+    const errText = await response.text();
+    throw new Error(`Failed to upload file to Google Drive: ${errText}`);
+  }
+
+  return await response.json();
+}
+
+/**
+ * Resets cached folder ID on user sign out.
+ */
+export function resetDriveCache() {
+  cachedFolderId = null;
+}


### PR DESCRIPTION
Closes #2

## Summary
- Added `https://www.googleapis.com/auth/drive.file` OAuth scope to `GoogleAuthProvider` in `public/js/auth.js`.
- Added access token caching and retrieval logic in `public/js/auth.js`.
- Created `public/js/drive.js` module to query Google Drive REST API for the `etype_drafts` folder and automatically create it if missing.
- Implemented `saveDraftToDrive` helper function in `public/js/drive.js` for multipart markdown file uploads.
- Updated `.github/workflows/deploy.yml` validation tests.