### PR TITLE
feat: Save drafts to Google Drive 'etype_drafts' folder with filename prompt (#3)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
           grep -q 'id="hidden-input"' public/index.html || (echo "Missing #hidden-input" && exit 1)
           grep -q 'id="toolbar"' public/index.html || (echo "Missing #toolbar" && exit 1)
           grep -q 'id="btn-auth"' public/index.html || (echo "Missing #btn-auth" && exit 1)
+          grep -q 'id="btn-gdrive"' public/index.html || (echo "Missing #btn-gdrive" && exit 1)
           echo "HTML structure verified successfully."
 
       - name: Validate JS ES modules

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -313,6 +313,60 @@ dialog::backdrop {
   background: #1a1a1a;
 }
 
+.form-group {
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-group label {
+  font-size: 0.75rem;
+  color: var(--toolbar-text);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.form-group input {
+  background: rgba(0,0,0,0.04);
+  border: 1px solid rgba(0,0,0,0.15);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--ink-color);
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.form-group input:focus {
+  border-color: var(--accent);
+  background: #fff;
+}
+
+.toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--ink-color);
+  color: var(--paper-bg);
+  padding: 10px 20px;
+  border-radius: 20px;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+  z-index: 1000;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  pointer-events: none;
+}
+
+.toast.hidden {
+  opacity: 0;
+  transform: translate(-50%, 10px);
+}
+
 @media (max-width: 640px) {
   body {
     align-items: flex-start;

--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,10 @@
             <!-- inline SVG: plus icon, 20x20, stroke only, strokeWidth 2, color currentColor -->
             <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="10" y1="4" x2="10" y2="16"/><line x1="4" y1="10" x2="16" y2="10"/></svg>
           </button>
+          <button id="btn-gdrive" type="button" title="Save to Google Drive" aria-label="Save to Google Drive">
+            <!-- inline SVG: cloud upload icon, 20x20 -->
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 18a3.5 3.5 0 0 0 0-7h-1A5 5 0 0 0 7 9a3.5 3.5 0 0 0 0 7h12z"/><path d="M12 12v6"/><path d="m15 15-3-3-3 3"/></svg>
+          </button>
           <button id="btn-download" type="button" title="Download as Markdown" aria-label="Download as Markdown">
             <!-- inline SVG: download arrow icon, 20x20, stroke only -->
             <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 3v10m0 0l-4-4m4 4l4-4"/><line x1="4" y1="17" x2="16" y2="17"/></svg>
@@ -51,6 +55,25 @@
       </div>
     </div>
   </dialog>
+
+  <dialog id="gdrive-dialog">
+    <div class="dialog-content">
+      <h2>Save to Google Drive</h2>
+      <p>Save draft to <strong>etype_drafts</strong> folder in Google Drive.</p>
+      <div class="form-group">
+        <label for="gdrive-title-input">Document Title</label>
+        <input type="text" id="gdrive-title-input" autocomplete="off" spellcheck="false">
+      </div>
+      <div class="dialog-actions">
+        <button id="btn-cancel-gdrive" type="button" class="btn-secondary">Cancel</button>
+        <button id="btn-confirm-gdrive" type="button" class="btn-primary">Save to Drive</button>
+      </div>
+    </div>
+  </dialog>
+
+  <div id="toast" class="toast hidden" role="status" aria-live="polite">
+    <span id="toast-message">Draft saved to Google Drive</span>
+  </div>
 
   <script type="module" src="/js/app.js"></script>
 </body>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3,7 +3,8 @@
 import { Typewriter } from './typewriter.js';
 import { UI } from './ui.js';
 import * as Storage from './storage.js';
-import { loginWithGoogle, logout, onUserChanged } from './auth.js';
+import { loginWithGoogle, logout, onUserChanged, getAccessToken } from './auth.js';
+import { saveDraftToDrive, resetDriveCache } from './drive.js';
 
 // Debounce helper
 function debounce(fn, ms) {
@@ -23,11 +24,19 @@ function init() {
   const wordCountEl = document.getElementById('word-count');
   const titleInputEl = document.getElementById('title-input');
   const authBtnEl = document.getElementById('btn-auth');
+  const gdriveBtnEl = document.getElementById('btn-gdrive');
   const newBtnEl = document.getElementById('btn-new');
   const downloadBtnEl = document.getElementById('btn-download');
   const dialogEl = document.getElementById('new-draft-dialog');
   const confirmBtnEl = document.getElementById('btn-confirm-new');
   const cancelBtnEl = document.getElementById('btn-cancel-new');
+
+  const gdriveDialogEl = document.getElementById('gdrive-dialog');
+  const gdriveTitleInputEl = document.getElementById('gdrive-title-input');
+  const confirmGdriveBtnEl = document.getElementById('btn-confirm-gdrive');
+  const cancelGdriveBtnEl = document.getElementById('btn-cancel-gdrive');
+  const toastEl = document.getElementById('toast');
+  const toastMessageEl = document.getElementById('toast-message');
   
   let currentUser = null;
 
@@ -37,11 +46,18 @@ function init() {
     wordCount: wordCountEl,
     titleInput: titleInputEl,
     authBtn: authBtnEl,
+    gdriveBtn: gdriveBtnEl,
     newBtn: newBtnEl,
     downloadBtn: downloadBtnEl,
     dialog: dialogEl,
     confirmBtn: confirmBtnEl,
     cancelBtn: cancelBtnEl,
+    gdriveDialog: gdriveDialogEl,
+    gdriveTitleInput: gdriveTitleInputEl,
+    confirmGdriveBtn: confirmGdriveBtnEl,
+    cancelGdriveBtn: cancelGdriveBtnEl,
+    toast: toastEl,
+    toastMessage: toastMessageEl,
   });
   
   // ---- Auto-save (debounced) ----
@@ -78,6 +94,9 @@ function init() {
   onUserChanged((user) => {
     currentUser = user;
     ui.setAuthState(user);
+    if (!user) {
+      resetDriveCache();
+    }
   });
 
   // ---- Bind UI handlers ----
@@ -86,6 +105,7 @@ function init() {
       if (currentUser) {
         try {
           await logout();
+          resetDriveCache();
         } catch (err) {
           console.error('Logout failed:', err);
         }
@@ -96,6 +116,37 @@ function init() {
           console.error('Login failed:', err);
         }
       }
+    },
+
+    onGDrive: async () => {
+      let token = getAccessToken();
+      if (!currentUser || !token) {
+        try {
+          const authResult = await loginWithGoogle();
+          token = authResult.accessToken;
+        } catch (err) {
+          return;
+        }
+      }
+
+      const text = typewriter.getText();
+      if (!text.trim()) {
+        ui.showToast('Draft is empty. Type something first!');
+        return;
+      }
+
+      ui.showGDriveDialog(ui.getTitle(), async (customTitle) => {
+        try {
+          ui.showToast('Saving to Google Drive...');
+          const activeToken = getAccessToken();
+          const file = await saveDraftToDrive(activeToken, customTitle, text);
+          ui.setTitle(customTitle);
+          ui.showToast(`Saved "${file.name}" to etype_drafts in Google Drive!`);
+        } catch (err) {
+          console.error('Google Drive save error:', err);
+          ui.showToast('Failed to save to Google Drive. Please try again.');
+        }
+      });
     },
 
     onNew: () => {

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -18,13 +18,22 @@ export class UI {
     this.titleInput = elements.titleInput;
     this.newBtn = elements.newBtn;
     this.downloadBtn = elements.downloadBtn;
+    this.gdriveBtn = elements.gdriveBtn;
     this.authBtn = elements.authBtn;
     this.authLabel = this.authBtn ? this.authBtn.querySelector('.auth-label') : null;
     this.dialog = elements.dialog;
     this.confirmBtn = elements.confirmBtn;
     this.cancelBtn = elements.cancelBtn;
+    this.gdriveDialog = elements.gdriveDialog;
+    this.gdriveTitleInput = elements.gdriveTitleInput;
+    this.confirmGdriveBtn = elements.confirmGdriveBtn;
+    this.cancelGdriveBtn = elements.cancelGdriveBtn;
+    this.toast = elements.toast;
+    this.toastMessage = elements.toastMessage;
     
     this._onNewDraftConfirm = null;
+    this._onGDriveConfirm = null;
+    this._toastTimer = null;
   }
   
   /**
@@ -122,10 +131,44 @@ export class UI {
   }
 
   /**
+   * Show the Google Drive save dialog.
+   * @param {string} defaultTitle - Initial title string
+   * @param {Function} onConfirm - Called with (title) if confirmed
+   */
+  showGDriveDialog(defaultTitle, onConfirm) {
+    if (!this.gdriveDialog) return;
+    this._onGDriveConfirm = onConfirm;
+    if (this.gdriveTitleInput) {
+      this.gdriveTitleInput.value = defaultTitle || 'Untitled Draft';
+    }
+    this.gdriveDialog.showModal();
+    if (this.gdriveTitleInput) {
+      this.gdriveTitleInput.select();
+    }
+  }
+
+  /**
+   * Display a floating toast notification.
+   * @param {string} message
+   * @param {number} [duration=3500]
+   */
+  showToast(message, duration = 3500) {
+    if (!this.toast || !this.toastMessage) return;
+    this.toastMessage.textContent = message;
+    this.toast.classList.remove('hidden');
+
+    if (this._toastTimer) clearTimeout(this._toastTimer);
+    this._toastTimer = setTimeout(() => {
+      this.toast.classList.add('hidden');
+    }, duration);
+  }
+
+  /**
    * Bind UI event handlers.
    * @param {Object} handlers
    * @param {Function} handlers.onNew - Called when "New Draft" button clicked
    * @param {Function} handlers.onDownload - Called when "Download" button clicked
+   * @param {Function} handlers.onGDrive - Called when "Save to Google Drive" button clicked
    * @param {Function} handlers.onTitleChange - Called when title input changes
    * @param {Function} handlers.onAuth - Called when auth button clicked
    */
@@ -134,6 +177,13 @@ export class UI {
     if (this.authBtn) {
       this.authBtn.addEventListener('click', () => {
         if (handlers.onAuth) handlers.onAuth();
+      });
+    }
+
+    // Google Drive button
+    if (this.gdriveBtn) {
+      this.gdriveBtn.addEventListener('click', () => {
+        if (handlers.onGDrive) handlers.onGDrive();
       });
     }
 
@@ -152,7 +202,7 @@ export class UI {
       if (handlers.onTitleChange) handlers.onTitleChange(this.getTitle());
     });
     
-    // Dialog confirm
+    // New draft Dialog confirm
     this.confirmBtn.addEventListener('click', () => {
       this.dialog.close();
       if (this._onNewDraftConfirm) {
@@ -161,13 +211,13 @@ export class UI {
       }
     });
     
-    // Dialog cancel
+    // New draft Dialog cancel
     this.cancelBtn.addEventListener('click', () => {
       this.dialog.close();
       this._onNewDraftConfirm = null;
     });
     
-    // Close dialog on backdrop click
+    // Close new draft dialog on backdrop click
     this.dialog.addEventListener('click', (e) => {
       if (e.target === this.dialog) {
         this.dialog.close();
@@ -175,9 +225,41 @@ export class UI {
       }
     });
     
-    // Close dialog on Escape (native behavior, but clean up callback)
+    // Close new draft dialog on Escape
     this.dialog.addEventListener('close', () => {
       this._onNewDraftConfirm = null;
     });
+
+    // Google Drive Dialog confirm
+    if (this.confirmGdriveBtn) {
+      this.confirmGdriveBtn.addEventListener('click', () => {
+        const title = (this.gdriveTitleInput ? this.gdriveTitleInput.value : '').trim();
+        this.gdriveDialog.close();
+        if (this._onGDriveConfirm) {
+          this._onGDriveConfirm(title || this.getTitle());
+          this._onGDriveConfirm = null;
+        }
+      });
+    }
+
+    // Google Drive Dialog cancel
+    if (this.cancelGdriveBtn) {
+      this.cancelGdriveBtn.addEventListener('click', () => {
+        this.gdriveDialog.close();
+        this._onGDriveConfirm = null;
+      });
+    }
+
+    if (this.gdriveDialog) {
+      this.gdriveDialog.addEventListener('click', (e) => {
+        if (e.target === this.gdriveDialog) {
+          this.gdriveDialog.close();
+          this._onGDriveConfirm = null;
+        }
+      });
+      this.gdriveDialog.addEventListener('close', () => {
+        this._onGDriveConfirm = null;
+      });
+    }
   }
 }


### PR DESCRIPTION
Closes #3

## Summary
- Added "Save to Google Drive" button (`#btn-gdrive`) in top toolbar.
- Added native modal dialog (`#gdrive-dialog`) allowing users to confirm or edit their document title before saving to Google Drive.
- Uploads markdown drafts directly to the user's `etype_drafts` folder using Google Drive API v3 multipart upload.
- Added toast notification component (`#toast`) for feedback upon successful upload or errors.
- Updated `.github/workflows/deploy.yml` validation tests.