### PR TITLE
fix: Fix Google Drive Save dialog callback, OAuth token persistence, and error feedback

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -119,32 +119,34 @@ function init() {
     },
 
     onGDrive: async () => {
-      let token = getAccessToken();
-      if (!currentUser || !token) {
-        try {
-          const authResult = await loginWithGoogle();
-          token = authResult.accessToken;
-        } catch (err) {
-          return;
-        }
-      }
-
       const text = typewriter.getText();
       if (!text.trim()) {
         ui.showToast('Draft is empty. Type something first!');
         return;
       }
 
+      // Open Save to Google Drive modal dialog immediately
       ui.showGDriveDialog(ui.getTitle(), async (customTitle) => {
         try {
-          ui.showToast('Saving to Google Drive...');
-          const activeToken = getAccessToken();
-          const file = await saveDraftToDrive(activeToken, customTitle, text);
+          ui.showToast('Connecting to Google Drive...');
+          let token = getAccessToken();
+
+          if (!currentUser || !token) {
+            const authResult = await loginWithGoogle();
+            token = authResult ? authResult.accessToken : getAccessToken();
+          }
+
+          if (!token) {
+            throw new Error('Google Sign-In is required to save to Google Drive.');
+          }
+
+          ui.showToast('Saving to etype_drafts folder...');
+          const file = await saveDraftToDrive(token, customTitle, text);
           ui.setTitle(customTitle);
           ui.showToast(`Saved "${file.name}" to etype_drafts in Google Drive!`);
         } catch (err) {
           console.error('Google Drive save error:', err);
-          ui.showToast('Failed to save to Google Drive. Please try again.');
+          ui.showToast(`Drive Error: ${err.message || 'Failed to save'}`);
         }
       });
     },

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -26,7 +26,7 @@ const googleProvider = new GoogleAuthProvider();
 // Request Google Drive file scope for saving drafts to etype_drafts folder
 googleProvider.addScope('https://www.googleapis.com/auth/drive.file');
 
-let currentAccessToken = sessionStorage.getItem('etype_gdrive_token') || null;
+let currentAccessToken = localStorage.getItem('etype_gdrive_token') || null;
 
 /**
  * Sign in with Google using popup.
@@ -38,7 +38,7 @@ export async function loginWithGoogle() {
     const credential = GoogleAuthProvider.credentialFromResult(result);
     if (credential && credential.accessToken) {
       currentAccessToken = credential.accessToken;
-      sessionStorage.setItem('etype_gdrive_token', currentAccessToken);
+      localStorage.setItem('etype_gdrive_token', currentAccessToken);
     }
     return { user: result.user, accessToken: currentAccessToken };
   } catch (error) {
@@ -54,7 +54,18 @@ export async function loginWithGoogle() {
  * @returns {string|null}
  */
 export function getAccessToken() {
+  if (!currentAccessToken) {
+    currentAccessToken = localStorage.getItem('etype_gdrive_token');
+  }
   return currentAccessToken;
+}
+
+/**
+ * Clear cached access token (e.g. on 401 error).
+ */
+export function clearAccessToken() {
+  currentAccessToken = null;
+  localStorage.removeItem('etype_gdrive_token');
 }
 
 /**
@@ -64,8 +75,7 @@ export function getAccessToken() {
 export async function logout() {
   try {
     await signOut(auth);
-    currentAccessToken = null;
-    sessionStorage.removeItem('etype_gdrive_token');
+    clearAccessToken();
   } catch (error) {
     console.error('E-Type Logout Error:', error);
     throw error;
@@ -80,8 +90,7 @@ export async function logout() {
 export function onUserChanged(callback) {
   return onAuthStateChanged(auth, (user) => {
     if (!user) {
-      currentAccessToken = null;
-      sessionStorage.removeItem('etype_gdrive_token');
+      clearAccessToken();
     }
     callback(user);
   });

--- a/public/js/drive.js
+++ b/public/js/drive.js
@@ -1,5 +1,7 @@
 // drive.js — Google Drive API integration for etype_drafts folder and uploads
 
+import { clearAccessToken } from './auth.js';
+
 const DRIVE_API_BASE = 'https://www.googleapis.com/drive/v3';
 const UPLOAD_API_BASE = 'https://www.googleapis.com/upload/drive/v3';
 const FOLDER_NAME = 'etype_drafts';
@@ -29,6 +31,12 @@ export async function getOrCreateDraftsFolder(accessToken) {
     }
   });
 
+  if (response.status === 401) {
+    clearAccessToken();
+    resetDriveCache();
+    throw new Error('Google authorization expired. Please sign in again.');
+  }
+
   if (!response.ok) {
     const errText = await response.text();
     throw new Error(`Google Drive API error (${response.status}): ${errText}`);
@@ -52,6 +60,12 @@ export async function getOrCreateDraftsFolder(accessToken) {
       mimeType: 'application/vnd.google-apps.folder'
     })
   });
+
+  if (createResponse.status === 401) {
+    clearAccessToken();
+    resetDriveCache();
+    throw new Error('Google authorization expired. Please sign in again.');
+  }
 
   if (!createResponse.ok) {
     const errText = await createResponse.text();
@@ -103,6 +117,12 @@ export async function saveDraftToDrive(accessToken, title, content) {
     },
     body: multipartRequestBody
   });
+
+  if (response.status === 401) {
+    clearAccessToken();
+    resetDriveCache();
+    throw new Error('Google authorization expired. Please sign in again.');
+  }
 
   if (!response.ok) {
     const errText = await response.text();

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -204,24 +204,25 @@ export class UI {
     
     // New draft Dialog confirm
     this.confirmBtn.addEventListener('click', () => {
+      const cb = this._onNewDraftConfirm;
+      this._onNewDraftConfirm = null;
       this.dialog.close();
-      if (this._onNewDraftConfirm) {
-        this._onNewDraftConfirm();
-        this._onNewDraftConfirm = null;
+      if (cb) {
+        cb();
       }
     });
     
     // New draft Dialog cancel
     this.cancelBtn.addEventListener('click', () => {
-      this.dialog.close();
       this._onNewDraftConfirm = null;
+      this.dialog.close();
     });
     
     // Close new draft dialog on backdrop click
     this.dialog.addEventListener('click', (e) => {
       if (e.target === this.dialog) {
-        this.dialog.close();
         this._onNewDraftConfirm = null;
+        this.dialog.close();
       }
     });
     
@@ -234,10 +235,11 @@ export class UI {
     if (this.confirmGdriveBtn) {
       this.confirmGdriveBtn.addEventListener('click', () => {
         const title = (this.gdriveTitleInput ? this.gdriveTitleInput.value : '').trim();
+        const cb = this._onGDriveConfirm;
+        this._onGDriveConfirm = null;
         this.gdriveDialog.close();
-        if (this._onGDriveConfirm) {
-          this._onGDriveConfirm(title || this.getTitle());
-          this._onGDriveConfirm = null;
+        if (cb) {
+          cb(title || this.getTitle());
         }
       });
     }
@@ -245,16 +247,16 @@ export class UI {
     // Google Drive Dialog cancel
     if (this.cancelGdriveBtn) {
       this.cancelGdriveBtn.addEventListener('click', () => {
-        this.gdriveDialog.close();
         this._onGDriveConfirm = null;
+        this.gdriveDialog.close();
       });
     }
 
     if (this.gdriveDialog) {
       this.gdriveDialog.addEventListener('click', (e) => {
         if (e.target === this.gdriveDialog) {
-          this.gdriveDialog.close();
           this._onGDriveConfirm = null;
+          this.gdriveDialog.close();
         }
       });
       this.gdriveDialog.addEventListener('close', () => {


### PR DESCRIPTION
## Root Cause Analysis & Fix
1. **Modal Event Bug**: HTML5 `<dialog>` fires its `close` event synchronously when `dialog.close()` is called. The `close` event listener was nullifying `this._onGDriveConfirm = null` before the click handler checked `if (this._onGDriveConfirm)`, causing the save callback to be wiped out without executing.
   - **Fix**: Saved callback reference (`const cb = this._onGDriveConfirm;`) prior to closing the dialog so the save workflow executes reliably.
2. **Immediate Dialog Opening**: Click handler for `#btn-gdrive` now immediately opens the document title prompt dialog. The Google Auth / OAuth popup is triggered directly inside the user's explicit modal confirm action, preventing browser popup blockers from suppressing the window.
3. **OAuth Token Persistence**: Persisted `etype_gdrive_token` in `localStorage` so OAuth tokens survive page refreshes, and added 401 token expiration handling in `public/js/drive.js`.
4. **Toast Error Feedback**: Any API / Auth errors are now surfaced clearly in floating toast messages instead of being caught and swallowed silently.