### PR TITLE
ci: Grant GITHUB_TOKEN permissions for PR preview check-runs and comments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
 
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+
 jobs:
   test:
     name: Verify & Validate


### PR DESCRIPTION
## Summary
- Fixed 403 `Resource not accessible by integration` error in GitHub Actions `pull_request` workflows.
- Added explicit `permissions:` block (`checks: write`, `contents: read`, `pull-requests: write`) in `.github/workflows/deploy.yml` so `FirebaseExtended/action-hosting-deploy` can create check-runs and post PR preview channel links.