### PR TITLE
fix: Trigger Google OAuth popup directly on Save button click gesture

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -119,29 +119,39 @@ function init() {
     },
 
     onGDrive: async () => {
-      const text = typewriter.getText();
-      if (!text.trim()) {
-        ui.showToast('Draft is empty. Type something first!');
+      let token = getAccessToken();
+
+      // If not logged in or token missing, authenticate immediately on button click gesture
+      if (!currentUser || !token) {
+        try {
+          ui.showToast('Signing in with Google...');
+          const authResult = await loginWithGoogle();
+          token = authResult ? authResult.accessToken : getAccessToken();
+        } catch (err) {
+          if (err && err.code !== 'auth/popup-closed-by-user') {
+            ui.showToast(`Auth Error: ${err.message || 'Sign in failed'}`);
+          }
+          return;
+        }
+      }
+
+      if (!token) {
+        ui.showToast('Google Sign-In is required to save to Google Drive.');
         return;
       }
 
-      // Open Save to Google Drive modal dialog immediately
+      const text = typewriter.getText();
+      if (!text.trim()) {
+        ui.showToast('Draft is empty. Type a few words before saving!');
+        return;
+      }
+
+      // Open Save to Google Drive modal dialog
       ui.showGDriveDialog(ui.getTitle(), async (customTitle) => {
         try {
-          ui.showToast('Connecting to Google Drive...');
-          let token = getAccessToken();
-
-          if (!currentUser || !token) {
-            const authResult = await loginWithGoogle();
-            token = authResult ? authResult.accessToken : getAccessToken();
-          }
-
-          if (!token) {
-            throw new Error('Google Sign-In is required to save to Google Drive.');
-          }
-
-          ui.showToast('Saving to etype_drafts folder...');
-          const file = await saveDraftToDrive(token, customTitle, text);
+          ui.showToast('Saving to etype_drafts folder in Google Drive...');
+          const activeToken = getAccessToken() || token;
+          const file = await saveDraftToDrive(activeToken, customTitle, text);
           ui.setTitle(customTitle);
           ui.showToast(`Saved "${file.name}" to etype_drafts in Google Drive!`);
         } catch (err) {

--- a/public/js/drive.js
+++ b/public/js/drive.js
@@ -22,7 +22,7 @@ export async function getOrCreateDraftsFolder(accessToken) {
   }
 
   // 1. Search for existing folder
-  const query = encodeURIComponent(`name = '${FOLDER_NAME}' and mimeType = 'application/vnd.google-apps.folder' and trashed = false`);
+  const query = encodeURIComponent(`name='${FOLDER_NAME}' and mimeType='application/vnd.google-apps.folder' and trashed=false`);
   const searchUrl = `${DRIVE_API_BASE}/files?q=${query}&fields=files(id,name)`;
 
   const response = await fetch(searchUrl, {


### PR DESCRIPTION
## Root Cause Analysis & Fix
- **Popup Blocker Issue**: Browsers suppress `signInWithPopup` if executed inside an async callback after delays or network ticks. Calling `loginWithGoogle` directly inside the `#btn-gdrive` click event handler ensures the OAuth popup window opens cleanly without being blocked by browser popup blockers.
- **Empty Draft Protection**: Displays a helpful toast message asking the user to type a few words before saving if the draft text is empty.
- **Refined Drive Search Query**: Updated Google Drive API v3 query encoding in `public/js/drive.js`.