### PR TITLE
feat: Add Hemingway Vintage Olive Green SVG favicon (#13)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
           grep -q 'id="toolbar"' public/index.html || (echo "Missing #toolbar" && exit 1)
           grep -q 'id="btn-auth"' public/index.html || (echo "Missing #btn-auth" && exit 1)
           grep -q 'id="btn-gdrive"' public/index.html || (echo "Missing #btn-gdrive" && exit 1)
+          grep -q 'rel="icon"' public/index.html || (echo "Missing favicon link" && exit 1)
           echo "HTML structure verified successfully."
 
       - name: Validate JS ES modules

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- E-paper cream background rounded card -->
+  <rect x="0" y="0" width="64" height="64" rx="14" fill="#f5f0e8"/>
+
+  <!-- Paper sheet feeding out the top -->
+  <rect x="20" y="10" width="24" height="18" rx="2" fill="#fffdfa" stroke="#4a572c" stroke-width="2"/>
+  <line x1="24" y1="16" x2="36" y2="16" stroke="#8a9965" stroke-width="2" stroke-linecap="round"/>
+  <line x1="24" y1="20" x2="40" y2="20" stroke="#8a9965" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- Platen roller / Carriage bar -->
+  <rect x="12" y="24" width="40" height="6" rx="3" fill="#2d351e"/>
+
+  <!-- Main Olive Green Typewriter Body -->
+  <path d="M 14 30 L 50 30 L 54 54 C 54 56.2 52.2 58 50 58 L 14 58 C 11.8 58 10 56.2 10 54 Z" fill="#5c6b3c"/>
+
+  <!-- Keyboard frame inset -->
+  <rect x="16" y="36" width="32" height="16" rx="3" fill="#2d351e"/>
+
+  <!-- Keys row 1 -->
+  <circle cx="21" cy="40" r="2.2" fill="#8a9965"/>
+  <circle cx="27" cy="40" r="2.2" fill="#8a9965"/>
+  <circle cx="33" cy="40" r="2.2" fill="#8a9965"/>
+  <circle cx="39" cy="40" r="2.2" fill="#8a9965"/>
+  <circle cx="45" cy="40" r="2.2" fill="#8a9965"/>
+
+  <!-- Keys row 2 (with Red Ribbon key accent) -->
+  <circle cx="21" cy="47" r="2.2" fill="#8a9965"/>
+  <circle cx="27" cy="47" r="2.2" fill="#d62828"/>
+  <circle cx="33" cy="47" r="2.2" fill="#8a9965"/>
+  <circle cx="39" cy="47" r="2.2" fill="#8a9965"/>
+  <circle cx="45" cy="47" r="2.2" fill="#8a9965"/>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Courier+Prime:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/index.css">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 </head>
 <body>
   <div id="app">


### PR DESCRIPTION
## Summary
- Added crisp vector SVG favicon (`public/favicon.svg`) featuring the **Hemingway Vintage Olive Green** 1950s Royal Quiet Deluxe typewriter with a crimson red ribbon key accent.
- Linked `favicon.svg` in `public/index.html` for crisp display across standard and Retina displays.
- Added validation check to `.github/workflows/deploy.yml`.