### PR TITLE
feat: Add distraction-free Info & Settings panels with autohide behavior (#14)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,8 @@ jobs:
           grep -q 'id="toolbar"' public/index.html || (echo "Missing #toolbar" && exit 1)
           grep -q 'id="btn-auth"' public/index.html || (echo "Missing #btn-auth" && exit 1)
           grep -q 'id="btn-gdrive"' public/index.html || (echo "Missing #btn-gdrive" && exit 1)
+          grep -q 'id="btn-info"' public/index.html || (echo "Missing #btn-info" && exit 1)
+          grep -q 'id="btn-settings"' public/index.html || (echo "Missing #btn-settings" && exit 1)
           grep -q 'rel="icon"' public/index.html || (echo "Missing favicon link" && exit 1)
           echo "HTML structure verified successfully."
 

--- a/docs/about.txt
+++ b/docs/about.txt
@@ -1,0 +1,11 @@
+There's a theory that there are two stages to writing.
+
+First drafts, where you get everything out without overthinking, and editing, where you can overthink as much as you want
+
+This app is for first drafts.
+
+Log in with your Google ID, give it permission to save things to a folder in your Google Drive. (That's all it does. All the code for this is in your browser, and you can see the app in the repo here.)
+
+You can't backspace, you can't delete, you can't move the cursor around. It's a typewriter. Write your draft, save it to Google Drive, and then edit it there.
+
+Enjoy.

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -405,3 +405,140 @@ dialog::backdrop {
     font-size: 0.9rem;
   }
 }
+
+/* Floating Controls (Info & Settings) */
+.floating-controls {
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  z-index: 100;
+  display: flex;
+  gap: 10px;
+  transition: opacity 0.4s ease, visibility 0.4s ease;
+}
+
+.btn-icon {
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(4px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--device-bezel);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.btn-icon:hover {
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.3);
+  transform: scale(1.05);
+}
+
+/* Distraction-Free Auto-Hide Rules */
+#toolbar,
+.floating-controls {
+  transition: opacity 0.4s ease, visibility 0.4s ease;
+}
+
+body.autohide-active #toolbar,
+body.autohide-active .floating-controls {
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+/* Dialog Form Enhancements */
+.form-group select {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--toolbar-text);
+  cursor: not-allowed;
+}
+
+.field-help {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.75rem;
+  color: var(--toolbar-text);
+}
+
+.dialog-footer-links {
+  margin-top: 16px;
+  margin-bottom: 20px;
+  padding-top: 12px;
+  border-top: 1px stroke rgba(0, 0, 0, 0.08);
+  font-size: 0.8rem;
+}
+
+.dialog-footer-links a {
+  color: var(--accent);
+  text-decoration: underline;
+  font-weight: 700;
+  transition: color 0.2s ease;
+}
+
+.dialog-footer-links a:hover {
+  color: var(--ink-color);
+}
+
+.privacy-note {
+  margin-top: 12px;
+  padding: 8px 12px;
+  background: rgba(0,0,0,0.04);
+  border-radius: 6px;
+  font-size: 0.8rem;
+}
+
+@media (max-width: 640px) {
+  body {
+    align-items: flex-start;
+    padding-top: 1rem;
+  }
+  #screen-container {
+    border-radius: 16px;
+    max-width: 100%;
+  }
+  #etype-screen {
+    height: 65vh;
+    margin: 0 12px 12px 12px;
+  }
+  #text-display {
+    padding: 20px 20px;
+    font-size: 0.95rem;
+  }
+  #toolbar {
+    padding: 10px 16px;
+  }
+  #title-input {
+    font-size: 0.75rem;
+    max-width: 160px;
+  }
+  #word-count {
+    font-size: 0.65rem;
+  }
+  .floating-controls {
+    bottom: 12px;
+    left: 12px;
+  }
+}
+
+@media (max-width: 380px) {
+  #etype-screen {
+    height: 60vh;
+  }
+  #text-display {
+    padding: 16px 16px;
+    font-size: 0.9rem;
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,14 @@
         <div id="text-display"><span id="cursor" class="cursor">█</span></div>
       </div>
     </div>
+    <div id="floating-controls" class="floating-controls">
+      <button id="btn-info" type="button" class="btn-icon" title="About E-Type" aria-label="About E-Type">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+      </button>
+      <button id="btn-settings" type="button" class="btn-icon" title="Settings" aria-label="Settings">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      </button>
+    </div>
   </div>
 
   <textarea id="hidden-input" autocapitalize="sentences" autocomplete="off" autocorrect="off" spellcheck="false" aria-label="Type your draft here"></textarea>
@@ -60,7 +68,7 @@
   <dialog id="gdrive-dialog">
     <div class="dialog-content">
       <h2>Save to Google Drive</h2>
-      <p>Save draft to <strong>etype_drafts</strong> folder in Google Drive.</p>
+      <p>Save draft to <strong id="gdrive-folder-display">etype_drafts</strong> folder in Google Drive.</p>
       <div class="form-group">
         <label for="gdrive-title-input">Document Title</label>
         <input type="text" id="gdrive-title-input" autocomplete="off" spellcheck="false">
@@ -68,6 +76,53 @@
       <div class="dialog-actions">
         <button id="btn-cancel-gdrive" type="button" class="btn-secondary">Cancel</button>
         <button id="btn-confirm-gdrive" type="button" class="btn-primary">Save to Drive</button>
+      </div>
+    </div>
+  </dialog>
+
+  <dialog id="info-dialog">
+    <div class="dialog-content">
+      <h2>About E-Type</h2>
+      <p>There's a theory that there are two stages to writing: <strong>first drafts</strong>, where you get everything out without overthinking, and <strong>editing</strong>, where you can overthink as much as you want.</p>
+      <p>This app is for first drafts.</p>
+      <p>Log in with your Google ID and give it permission to save things to a folder in your Google Drive. (That's all it does. All the code for this is in your browser.)</p>
+      <p>You can't backspace, you can't delete, you can't move the cursor around. It's a typewriter. Write your draft, save it to Google Drive, and edit it there.</p>
+      <p>Enjoy.</p>
+      <div class="dialog-footer-links">
+        <a href="https://github.com/grahamsw/etype-emulator" target="_blank" rel="noopener">View Source on GitHub ↗</a>
+      </div>
+      <div class="dialog-actions">
+        <button id="btn-close-info" type="button" class="btn-primary">Close</button>
+      </div>
+    </div>
+  </dialog>
+
+  <dialog id="settings-dialog">
+    <div class="dialog-content">
+      <h2>Settings</h2>
+      <div class="form-group">
+        <label for="settings-drive-folder">Google Drive Folder Name</label>
+        <input type="text" id="settings-drive-folder" value="etype_drafts" autocomplete="off" spellcheck="false">
+        <small class="field-help">Drafts will be saved to this folder in your Google Drive.</small>
+      </div>
+      <div class="form-group">
+        <label>Font & Aesthetic</label>
+        <select id="settings-font-select" disabled>
+          <option value="courier">Courier Prime (Default Typewriter)</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label>Theme</label>
+        <select id="settings-theme-select" disabled>
+          <option value="warm-cream">Warm Cream E-Paper (Default)</option>
+        </select>
+      </div>
+      <div class="dialog-footer-links">
+        <a href="mailto:graham.stalker@gmail.com?subject=E-Type%20Feedback" target="_blank" rel="noopener">Contact Developer / Send Feedback ✉</a>
+      </div>
+      <div class="dialog-actions">
+        <button id="btn-cancel-settings" type="button" class="btn-secondary">Cancel</button>
+        <button id="btn-save-settings" type="button" class="btn-primary">Save Settings</button>
       </div>
     </div>
   </dialog>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -21,6 +21,7 @@ function init() {
   const inputEl = document.getElementById('hidden-input');
   const cursorEl = document.getElementById('cursor');
   const screenEl = document.getElementById('etype-screen');
+  const screenContainerEl = document.getElementById('screen-container');
   const wordCountEl = document.getElementById('word-count');
   const titleInputEl = document.getElementById('title-input');
   const authBtnEl = document.getElementById('btn-auth');
@@ -35,10 +36,22 @@ function init() {
   const gdriveTitleInputEl = document.getElementById('gdrive-title-input');
   const confirmGdriveBtnEl = document.getElementById('btn-confirm-gdrive');
   const cancelGdriveBtnEl = document.getElementById('btn-cancel-gdrive');
+  const gdriveFolderDisplayEl = document.getElementById('gdrive-folder-display');
+
+  const infoBtnEl = document.getElementById('btn-info');
+  const settingsBtnEl = document.getElementById('btn-settings');
+  const infoDialogEl = document.getElementById('info-dialog');
+  const closeInfoBtnEl = document.getElementById('btn-close-info');
+  const settingsDialogEl = document.getElementById('settings-dialog');
+  const settingsFolderInputEl = document.getElementById('settings-drive-folder');
+  const cancelSettingsBtnEl = document.getElementById('btn-cancel-settings');
+  const saveSettingsBtnEl = document.getElementById('btn-save-settings');
+
   const toastEl = document.getElementById('toast');
   const toastMessageEl = document.getElementById('toast-message');
   
   let currentUser = null;
+  let appSettings = Storage.loadSettings();
 
   // ---- Initialize UI ----
   const ui = new UI({
@@ -56,10 +69,53 @@ function init() {
     gdriveTitleInput: gdriveTitleInputEl,
     confirmGdriveBtn: confirmGdriveBtnEl,
     cancelGdriveBtn: cancelGdriveBtnEl,
+    gdriveFolderDisplay: gdriveFolderDisplayEl,
+    infoBtn: infoBtnEl,
+    settingsBtn: settingsBtnEl,
+    infoDialog: infoDialogEl,
+    closeInfoBtn: closeInfoBtnEl,
+    settingsDialog: settingsDialogEl,
+    settingsFolderInput: settingsFolderInputEl,
+    cancelSettingsBtn: cancelSettingsBtnEl,
+    saveSettingsBtn: saveSettingsBtnEl,
     toast: toastEl,
     toastMessage: toastMessageEl,
   });
   
+  // ---- Distraction-Free Auto-Hide Handling ----
+  let autohideTimer = null;
+
+  const revealUI = () => {
+    ui.setAutohide(false);
+  };
+
+  const hideUI = () => {
+    ui.setAutohide(true);
+  };
+
+  // Mouse movement auto-hide rules
+  document.addEventListener('mousemove', (e) => {
+    // If mouse is outside screen container (outer margins / edges), reveal controls
+    const rect = screenContainerEl ? screenContainerEl.getBoundingClientRect() : null;
+    if (rect) {
+      const isInsidePaper = (
+        e.clientX >= rect.left &&
+        e.clientX <= rect.right &&
+        e.clientY >= rect.top &&
+        e.clientY <= rect.bottom
+      );
+      if (!isInsidePaper) {
+        revealUI();
+        return;
+      }
+    }
+
+    // Inside paper area while typing -> auto-hide UI
+    if (typewriter.hasTyped) {
+      hideUI();
+    }
+  });
+
   // ---- Auto-save (debounced) ----
   let createdAt = new Date().toISOString();
   
@@ -76,6 +132,9 @@ function init() {
     onTextChange: (text) => {
       ui.updateWordCount(text);
       autoSave();
+    },
+    onTypingStart: () => {
+      hideUI();
     },
   });
   
@@ -96,6 +155,7 @@ function init() {
     ui.setAuthState(user);
     if (!user) {
       resetDriveCache();
+      revealUI();
     }
   });
 
@@ -116,6 +176,14 @@ function init() {
           console.error('Login failed:', err);
         }
       }
+    },
+
+    onRequestSettings: () => {
+      ui.showSettingsDialog(appSettings, (newSettings) => {
+        appSettings = newSettings;
+        Storage.saveSettings(newSettings);
+        ui.showToast(`Settings saved. Folder: ${appSettings.driveFolder}`);
+      });
     },
 
     onGDrive: async () => {
@@ -146,14 +214,16 @@ function init() {
         return;
       }
 
+      const folderName = appSettings.driveFolder || 'etype_drafts';
+
       // Open Save to Google Drive modal dialog
-      ui.showGDriveDialog(ui.getTitle(), async (customTitle) => {
+      ui.showGDriveDialog(ui.getTitle(), folderName, async (customTitle) => {
         try {
-          ui.showToast('Saving to etype_drafts folder in Google Drive...');
+          ui.showToast(`Saving to ${folderName} folder in Google Drive...`);
           const activeToken = getAccessToken() || token;
-          const file = await saveDraftToDrive(activeToken, customTitle, text);
+          const file = await saveDraftToDrive(activeToken, customTitle, text, folderName);
           ui.setTitle(customTitle);
-          ui.showToast(`Saved "${file.name}" to etype_drafts in Google Drive!`);
+          ui.showToast(`Saved "${file.name}" to ${folderName} in Google Drive!`);
         } catch (err) {
           console.error('Google Drive save error:', err);
           ui.showToast(`Drive Error: ${err.message || 'Failed to save'}`);
@@ -171,6 +241,7 @@ function init() {
           ui.updateWordCount('');
           createdAt = new Date().toISOString();
           Storage.clearStorage();
+          revealUI();
           typewriter.focus();
         });
       } else {
@@ -179,6 +250,7 @@ function init() {
         ui.setTitle('Untitled Draft');
         createdAt = new Date().toISOString();
         Storage.clearStorage();
+        revealUI();
         typewriter.focus();
       }
     },
@@ -205,7 +277,6 @@ function init() {
   });
   
   // ---- Focus the typewriter on load ----
-  // Small delay to ensure everything is rendered
   setTimeout(() => typewriter.focus(), 100);
 }
 

--- a/public/js/drive.js
+++ b/public/js/drive.js
@@ -7,22 +7,25 @@ const UPLOAD_API_BASE = 'https://www.googleapis.com/upload/drive/v3';
 const FOLDER_NAME = 'etype_drafts';
 
 let cachedFolderId = null;
+let cachedFolderName = null;
 
 /**
- * Searches for the 'etype_drafts' folder in the user's Google Drive.
+ * Searches for the specified folder in the user's Google Drive.
  * Creates it if it does not exist.
  * @param {string} accessToken - Google OAuth Access Token
+ * @param {string} [folderName='etype_drafts'] - Target folder name
  * @returns {Promise<string>} Google Drive Folder ID
  */
-export async function getOrCreateDraftsFolder(accessToken) {
-  if (cachedFolderId) return cachedFolderId;
+export async function getOrCreateDraftsFolder(accessToken, folderName = FOLDER_NAME) {
+  const targetFolder = folderName.trim() || FOLDER_NAME;
+  if (cachedFolderId && cachedFolderName === targetFolder) return cachedFolderId;
 
   if (!accessToken) {
     throw new Error('No Google access token available. Please sign in with Google.');
   }
 
   // 1. Search for existing folder
-  const query = encodeURIComponent(`name='${FOLDER_NAME}' and mimeType='application/vnd.google-apps.folder' and trashed=false`);
+  const query = encodeURIComponent(`name='${targetFolder}' and mimeType='application/vnd.google-apps.folder' and trashed=false`);
   const searchUrl = `${DRIVE_API_BASE}/files?q=${query}&fields=files(id,name)`;
 
   const response = await fetch(searchUrl, {
@@ -45,6 +48,7 @@ export async function getOrCreateDraftsFolder(accessToken) {
   const data = await response.json();
   if (data.files && data.files.length > 0) {
     cachedFolderId = data.files[0].id;
+    cachedFolderName = targetFolder;
     return cachedFolderId;
   }
 
@@ -56,7 +60,7 @@ export async function getOrCreateDraftsFolder(accessToken) {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
-      name: FOLDER_NAME,
+      name: targetFolder,
       mimeType: 'application/vnd.google-apps.folder'
     })
   });
@@ -69,23 +73,25 @@ export async function getOrCreateDraftsFolder(accessToken) {
 
   if (!createResponse.ok) {
     const errText = await createResponse.text();
-    throw new Error(`Failed to create '${FOLDER_NAME}' folder in Google Drive: ${errText}`);
+    throw new Error(`Failed to create '${targetFolder}' folder in Google Drive: ${errText}`);
   }
 
   const createdFolder = await createResponse.json();
   cachedFolderId = createdFolder.id;
+  cachedFolderName = targetFolder;
   return cachedFolderId;
 }
 
 /**
- * Saves a markdown draft to the 'etype_drafts' folder in Google Drive.
+ * Saves a markdown draft to Google Drive.
  * @param {string} accessToken - Google OAuth Access Token
  * @param {string} title - File title/name
  * @param {string} content - Markdown draft content
+ * @param {string} [folderName='etype_drafts'] - Target folder name
  * @returns {Promise<{id: string, name: string, webViewLink: string}>} Uploaded file details
  */
-export async function saveDraftToDrive(accessToken, title, content) {
-  const folderId = await getOrCreateDraftsFolder(accessToken);
+export async function saveDraftToDrive(accessToken, title, content, folderName = FOLDER_NAME) {
+  const folderId = await getOrCreateDraftsFolder(accessToken, folderName);
   const filename = (title.trim() || 'Untitled Draft') + '.md';
 
   const metadata = {

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -35,6 +35,37 @@ export function load() {
   }
 }
 
+const SETTINGS_KEY = 'etype-settings';
+
+/**
+ * Save app settings to localStorage.
+ * @param {Object} settings - { driveFolder, theme, font }
+ */
+export function saveSettings(settings) {
+  try {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+  } catch (e) {
+    console.warn('E-Type: Failed to save settings', e);
+  }
+}
+
+/**
+ * Load app settings from localStorage.
+ * @returns {Object} Saved settings or defaults.
+ */
+export function loadSettings() {
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) return { driveFolder: 'etype_drafts' };
+    const parsed = JSON.parse(raw);
+    return {
+      driveFolder: parsed.driveFolder || 'etype_drafts'
+    };
+  } catch (e) {
+    return { driveFolder: 'etype_drafts' };
+  }
+}
+
 /**
  * Clear saved draft from localStorage.
  */

--- a/public/js/typewriter.js
+++ b/public/js/typewriter.js
@@ -18,6 +18,7 @@ export class Typewriter {
     this.cursorEl = cursorEl;
     this.onTextChange = options.onTextChange || null;
     this.onFirstChar = options.onFirstChar || null;
+    this.onTypingStart = options.onTypingStart || null;
     
     this.text = '';           // canonical text buffer (append-only during typing)
     this.queue = [];          // characters waiting to be rendered
@@ -59,6 +60,10 @@ export class Typewriter {
   // ---- Key Blocking ----
   
   _onKeyDown(e) {
+    if (this.onTypingStart) {
+      this.onTypingStart();
+    }
+
     // Block destructive / backward-movement keys
     const blockedKeys = ['Backspace', 'Delete', 'ArrowLeft', 'ArrowUp', 'Home'];
     if (blockedKeys.includes(e.key)) {

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -28,11 +28,21 @@ export class UI {
     this.gdriveTitleInput = elements.gdriveTitleInput;
     this.confirmGdriveBtn = elements.confirmGdriveBtn;
     this.cancelGdriveBtn = elements.cancelGdriveBtn;
+    this.gdriveFolderDisplay = elements.gdriveFolderDisplay;
+    this.infoBtn = elements.infoBtn;
+    this.settingsBtn = elements.settingsBtn;
+    this.infoDialog = elements.infoDialog;
+    this.closeInfoBtn = elements.closeInfoBtn;
+    this.settingsDialog = elements.settingsDialog;
+    this.settingsFolderInput = elements.settingsFolderInput;
+    this.cancelSettingsBtn = elements.cancelSettingsBtn;
+    this.saveSettingsBtn = elements.saveSettingsBtn;
     this.toast = elements.toast;
     this.toastMessage = elements.toastMessage;
     
     this._onNewDraftConfirm = null;
     this._onGDriveConfirm = null;
+    this._onSaveSettingsConfirm = null;
     this._toastTimer = null;
   }
   
@@ -133,17 +143,56 @@ export class UI {
   /**
    * Show the Google Drive save dialog.
    * @param {string} defaultTitle - Initial title string
+   * @param {string} folderName - Destination folder name
    * @param {Function} onConfirm - Called with (title) if confirmed
    */
-  showGDriveDialog(defaultTitle, onConfirm) {
+  showGDriveDialog(defaultTitle, folderName, onConfirm) {
     if (!this.gdriveDialog) return;
     this._onGDriveConfirm = onConfirm;
+    if (this.gdriveFolderDisplay) {
+      this.gdriveFolderDisplay.textContent = folderName || 'etype_drafts';
+    }
     if (this.gdriveTitleInput) {
       this.gdriveTitleInput.value = defaultTitle || 'Untitled Draft';
     }
     this.gdriveDialog.showModal();
     if (this.gdriveTitleInput) {
       this.gdriveTitleInput.select();
+    }
+  }
+
+  /**
+   * Show the Info modal dialog.
+   */
+  showInfoDialog() {
+    if (this.infoDialog) {
+      this.infoDialog.showModal();
+    }
+  }
+
+  /**
+   * Show the Settings modal dialog.
+   * @param {Object} currentSettings - { driveFolder }
+   * @param {Function} onSave - Called with (newSettings)
+   */
+  showSettingsDialog(currentSettings, onSave) {
+    if (!this.settingsDialog) return;
+    this._onSaveSettingsConfirm = onSave;
+    if (this.settingsFolderInput) {
+      this.settingsFolderInput.value = currentSettings.driveFolder || 'etype_drafts';
+    }
+    this.settingsDialog.showModal();
+  }
+
+  /**
+   * Toggle distraction-free auto-hide of toolbar and floating controls.
+   * @param {boolean} hide - True to hide UI, false to reveal UI
+   */
+  setAutohide(hide) {
+    if (hide) {
+      document.body.classList.add('autohide-active');
+    } else {
+      document.body.classList.remove('autohide-active');
     }
   }
 
@@ -171,6 +220,7 @@ export class UI {
    * @param {Function} handlers.onGDrive - Called when "Save to Google Drive" button clicked
    * @param {Function} handlers.onTitleChange - Called when title input changes
    * @param {Function} handlers.onAuth - Called when auth button clicked
+   * @param {Function} handlers.onSaveSettings - Called with ({ driveFolder })
    */
   bindHandlers(handlers) {
     // Auth button
@@ -184,6 +234,59 @@ export class UI {
     if (this.gdriveBtn) {
       this.gdriveBtn.addEventListener('click', () => {
         if (handlers.onGDrive) handlers.onGDrive();
+      });
+    }
+
+    // Info button
+    if (this.infoBtn) {
+      this.infoBtn.addEventListener('click', () => {
+        this.showInfoDialog();
+      });
+    }
+
+    // Settings button
+    if (this.settingsBtn) {
+      this.settingsBtn.addEventListener('click', () => {
+        if (handlers.onRequestSettings) handlers.onRequestSettings();
+      });
+    }
+
+    // Close Info dialog
+    if (this.closeInfoBtn && this.infoDialog) {
+      this.closeInfoBtn.addEventListener('click', () => {
+        this.infoDialog.close();
+      });
+      this.infoDialog.addEventListener('click', (e) => {
+        if (e.target === this.infoDialog) this.infoDialog.close();
+      });
+    }
+
+    // Settings Dialog save & cancel
+    if (this.saveSettingsBtn && this.settingsDialog) {
+      this.saveSettingsBtn.addEventListener('click', () => {
+        const driveFolder = (this.settingsFolderInput ? this.settingsFolderInput.value : '').trim() || 'etype_drafts';
+        const cb = this._onSaveSettingsConfirm;
+        this._onSaveSettingsConfirm = null;
+        this.settingsDialog.close();
+        if (cb) {
+          cb({ driveFolder });
+        }
+      });
+    }
+
+    if (this.cancelSettingsBtn && this.settingsDialog) {
+      this.cancelSettingsBtn.addEventListener('click', () => {
+        this._onSaveSettingsConfirm = null;
+        this.settingsDialog.close();
+      });
+      this.settingsDialog.addEventListener('click', (e) => {
+        if (e.target === this.settingsDialog) {
+          this._onSaveSettingsConfirm = null;
+          this.settingsDialog.close();
+        }
+      });
+      this.settingsDialog.addEventListener('close', () => {
+        this._onSaveSettingsConfirm = null;
       });
     }
 


### PR DESCRIPTION
## Summary
- Added **Info `(i)`** and **Settings `⚙`** floating controls ().
- **Distraction-Free Auto-Hide**:
  - Controls and toolbar automatically fade out completely (`opacity: 0; pointer-events: none`) when typing or when the mouse is positioned inside the active typing area.
  - Controls & toolbar smoothly fade back in when moving the mouse to the outer margins/edges of the screen or when unauthenticated.
- **Info Dialog (`#info-dialog`)**: Displays E-Type's first draft philosophy text (from `docs/about.txt`), client-side privacy note, and link to GitHub repository.
- **Settings Dialog (`#settings-dialog`)**: Allows customizing the Google Drive destination folder name (persisted in `localStorage`, default: `etype_drafts`), contact link, and placeholder hooks for future themes & fonts.

Closes #14.