### PR TITLE
feat: Auto-focus typewriter on global clicks, page boot, dialog close, and window focus (#17)

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -254,6 +254,30 @@ function init() {
     onTitleChange: () => {
       autoSave();
     },
+
+    onDialogClose: () => {
+      focusTypewriter();
+    },
+  });
+
+  // ---- Global Focus Management (Distraction-Free Typewriter Focus) ----
+  const focusTypewriter = () => {
+    if (document.querySelector('dialog[open]')) return;
+    typewriter.focus();
+  };
+
+  // Global click listener: clicking background canvas, bezel, or paper sets focus to typewriter
+  document.addEventListener('click', (e) => {
+    if (document.querySelector('dialog[open]')) return;
+    const isInteractive = e.target.closest('button, input, select, textarea, a, label, dialog');
+    if (!isInteractive) {
+      focusTypewriter();
+    }
+  });
+
+  // Window focus listener (switching tabs or returning to app)
+  window.addEventListener('focus', () => {
+    focusTypewriter();
   });
   
   // ---- Save on page unload ----
@@ -266,7 +290,7 @@ function init() {
   });
   
   // ---- Focus the typewriter on load ----
-  setTimeout(() => typewriter.focus(), 100);
+  setTimeout(() => focusTypewriter(), 100);
 }
 
 // ---- Boot ----

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -362,9 +362,14 @@ export class UI {
           this.gdriveDialog.close();
         }
       });
-      this.gdriveDialog.addEventListener('close', () => {
-        this._onGDriveConfirm = null;
-      });
-    }
+    // Bind close events on all dialogs to refocus typewriter
+    const allDialogs = [this.dialog, this.gdriveDialog, this.infoDialog, this.settingsDialog];
+    allDialogs.forEach((d) => {
+      if (d) {
+        d.addEventListener('close', () => {
+          if (handlers.onDialogClose) handlers.onDialogClose();
+        });
+      }
+    });
   }
 }


### PR DESCRIPTION
## Summary
- **Global Click Focus**: Clicking anywhere on the page (dark outer background, grey device bezel, or e-paper screen) automatically sets keyboard focus to the typewriter.
- **Interactive Element Protection**: Does not steal focus if clicking on buttons, inputs, links, or open modal dialogs.
- **Dialog Dismissal Focus**: Closing any modal dialog (Save to Drive, Settings, Info, New Draft) instantly refocuses the typewriter.
- **Tab / Window Focus**: Switching back to the browser tab automatically readies the typewriter for typing.
- **Initial Boot Focus**: Auto-focuses the typewriter on initial app boot.

No excuses — always ready to type!