### PR TITLE
fix: Set Cross-Origin-Opener-Policy same-origin-allow-popups for Firebase Auth popups

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -22,6 +22,15 @@
     ],
     "headers": [
       {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Cross-Origin-Opener-Policy",
+            "value": "same-origin-allow-popups"
+          }
+        ]
+      },
+      {
         "source": "**/*.@(js|css)",
         "headers": [
           {

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="E-Type: A distraction-free e-ink typewriter emulator for first drafts. Write forward, never look back.">
+  <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin-allow-popups">
   <title>E-Type — E-Ink Typewriter</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Root Cause and Fix
- Modern browsers block window.close and postMessage calls between Google Auth popup windows and the parent app if Cross-Origin-Opener-Policy is default or missing.
- Added Cross-Origin-Opener-Policy same-origin-allow-popups header to firebase.json and index.html meta tag so Firebase Auth popups close cleanly.