### PR TITLE
feat: Relocate toolbar to bottom of bezel, fix word-count in bottom-left, add mouse-idle reveal and A11y

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -52,7 +52,7 @@ body {
 #screen-container {
   background: linear-gradient(to bottom, var(--device-bezel), var(--device-bezel-dark));
   border-radius: 20px;
-  padding: 0;
+  padding: 20px 20px 0 20px;
   box-shadow: 
     0 8px 32px rgba(0,0,0,0.4),
     0 2px 8px rgba(0,0,0,0.2),
@@ -60,15 +60,64 @@ body {
   width: 100%;
   max-width: calc(var(--screen-max-width) + 48px);
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+#etype-screen {
+  background-color: var(--paper-bg);
+  border-radius: 4px;
+  height: var(--screen-height);
+  overflow-y: auto;
+  overflow-x: hidden;
+  box-shadow: inset 0 2px 8px rgba(0,0,0,0.06), inset 0 0 0 1px rgba(0,0,0,0.04);
+  position: relative;
+}
+
+#device-footer {
+  padding: 12px 16px;
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: all 0.3s ease;
+}
+
+.status-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+#word-count {
+  font-size: 0.75rem;
+  color: var(--toolbar-text);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  font-weight: 700;
+  opacity: 0.85;
 }
 
 #toolbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 24px;
-  background: transparent;
-  border-bottom: 1px solid rgba(0,0,0,0.08);
+  padding-top: 8px;
+  border-top: 1px solid rgba(0,0,0,0.08);
+  opacity: 0;
+  pointer-events: none;
+  max-height: 0;
+  overflow: hidden;
+  transition: opacity 0.3s ease, max-height 0.3s ease, padding 0.3s ease;
+}
+
+body.show-controls #toolbar,
+#toolbar:focus-within,
+#toolbar:has(:focus-visible) {
+  opacity: 1;
+  pointer-events: auto;
+  max-height: 80px;
 }
 
 .toolbar-left {
@@ -101,14 +150,6 @@ body {
   align-items: center;
   gap: 12px;
   flex-shrink: 0;
-}
-
-#word-count {
-  font-size: 0.7rem;
-  color: var(--toolbar-text);
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  white-space: nowrap;
 }
 
 #toolbar button {
@@ -451,9 +492,25 @@ body.show-controls .floating-controls {
   transform: scale(1.1);
 }
 
-.btn-icon svg {
-  width: 22px;
-  height: 22px;
+/* Keyboard Accessibility & Motion Preferences */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.floating-controls:focus-within,
+.floating-controls:has(:focus-visible) {
+  opacity: 1 !important;
+  pointer-events: auto !important;
+  visibility: visible !important;
+  transform: translateY(0) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
 }
 
 /* Dialog Form Enhancements */

--- a/public/index.html
+++ b/public/index.html
@@ -15,33 +15,34 @@
 <body>
   <div id="app">
     <div id="screen-container">
-      <header id="toolbar">
-        <div class="toolbar-left">
-          <input type="text" id="title-input" value="Untitled Draft" spellcheck="false" autocomplete="off">
-        </div>
-        <div class="toolbar-right">
-          <span id="word-count">0 words</span>
-          <button id="btn-auth" type="button" class="btn-auth" title="Sign In with Google" aria-label="Sign In with Google">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="auth-icon"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
-            <span id="auth-label" class="auth-label">Sign In</span>
-          </button>
-          <button id="btn-new" type="button" title="New Draft" aria-label="New Draft">
-            <!-- inline SVG: plus icon, 20x20, stroke only, strokeWidth 2, color currentColor -->
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="10" y1="4" x2="10" y2="16"/><line x1="4" y1="10" x2="16" y2="10"/></svg>
-          </button>
-          <button id="btn-gdrive" type="button" title="Save to Google Drive" aria-label="Save to Google Drive">
-            <!-- inline SVG: cloud upload icon, 20x20 -->
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 18a3.5 3.5 0 0 0 0-7h-1A5 5 0 0 0 7 9a3.5 3.5 0 0 0 0 7h12z"/><path d="M12 12v6"/><path d="m15 15-3-3-3 3"/></svg>
-          </button>
-          <button id="btn-download" type="button" title="Download as Markdown" aria-label="Download as Markdown">
-            <!-- inline SVG: download arrow icon, 20x20, stroke only -->
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 3v10m0 0l-4-4m4 4l4-4"/><line x1="4" y1="17" x2="16" y2="17"/></svg>
-          </button>
-        </div>
-      </header>
       <div id="etype-screen">
         <div id="text-display"><span id="cursor" class="cursor">█</span></div>
       </div>
+      <footer id="device-footer">
+        <div class="status-bar">
+          <span id="word-count" aria-live="polite">0 words</span>
+        </div>
+        <header id="toolbar" class="toolbar-bottom">
+          <div class="toolbar-left">
+            <input type="text" id="title-input" value="Untitled Draft" spellcheck="false" autocomplete="off" aria-label="Draft Title">
+          </div>
+          <div class="toolbar-right">
+            <button id="btn-auth" type="button" class="btn-auth" title="Sign In with Google" aria-label="Sign In with Google">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="auth-icon"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+              <span id="auth-label" class="auth-label">Sign In</span>
+            </button>
+            <button id="btn-new" type="button" title="New Draft" aria-label="New Draft">
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="10" y1="4" x2="10" y2="16"/><line x1="4" y1="10" x2="16" y2="10"/></svg>
+            </button>
+            <button id="btn-gdrive" type="button" title="Save to Google Drive" aria-label="Save to Google Drive">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 18a3.5 3.5 0 0 0 0-7h-1A5 5 0 0 0 7 9a3.5 3.5 0 0 0 0 7h12z"/><path d="M12 12v6"/><path d="m15 15-3-3-3 3"/></svg>
+            </button>
+            <button id="btn-download" type="button" title="Download as Markdown" aria-label="Download as Markdown">
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 3v10m0 0l-4-4m4 4l4-4"/><line x1="4" y1="17" x2="16" y2="17"/></svg>
+            </button>
+          </div>
+        </header>
+      </footer>
     </div>
     <div id="floating-controls" class="floating-controls">
       <button id="btn-info" type="button" class="btn-icon" title="About E-Type" aria-label="About E-Type">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -82,30 +82,37 @@ function init() {
     toastMessage: toastMessageEl,
   });
   
-  // ---- Distraction-Free Controls Visibility ----
-  const updateControlsVisibility = (e) => {
-    if (!screenContainerEl) return;
-    const rect = screenContainerEl.getBoundingClientRect();
-    const isOutsideScreen = (
-      e.clientX < rect.left ||
-      e.clientX > rect.right ||
-      e.clientY < rect.top ||
-      e.clientY > rect.bottom
-    );
+  // ---- Distraction-Free Controls & Bottom Bar Visibility ----
+  let mouseIdleTimer = null;
 
-    if (isOutsideScreen) {
-      document.body.classList.add('show-controls');
-    } else {
+  const showControls = () => {
+    document.body.classList.add('show-controls');
+    if (mouseIdleTimer) clearTimeout(mouseIdleTimer);
+    // Controls hang around for 3 seconds after mouse stops moving
+    mouseIdleTimer = setTimeout(() => {
+      const focusedElement = document.activeElement;
+      const isFocusedInControls = focusedElement && focusedElement.closest('#toolbar, .floating-controls, dialog');
+      if (!isFocusedInControls) {
+        document.body.classList.remove('show-controls');
+      }
+    }, 3000);
+  };
+
+  const hideControlsImmediately = () => {
+    if (mouseIdleTimer) clearTimeout(mouseIdleTimer);
+    const focusedElement = document.activeElement;
+    const isFocusedInControls = focusedElement && focusedElement.closest('#toolbar, .floating-controls, dialog');
+    if (!isFocusedInControls) {
       document.body.classList.remove('show-controls');
     }
   };
 
-  window.addEventListener('mousemove', updateControlsVisibility);
+  window.addEventListener('mousemove', () => {
+    showControls();
+  });
 
-  window.addEventListener('touchstart', (e) => {
-    if (e.touches && e.touches.length > 0) {
-      updateControlsVisibility(e.touches[0]);
-    }
+  window.addEventListener('touchstart', () => {
+    showControls();
   }, { passive: true });
 
   // ---- Auto-save (debounced) ----
@@ -126,7 +133,7 @@ function init() {
       autoSave();
     },
     onTypingStart: () => {
-      document.body.classList.remove('show-controls');
+      hideControlsImmediately();
     },
   });
   


### PR DESCRIPTION
## Summary
- **Always-Visible Status Bar**: Word count (`#word-count`) is positioned in the **bottom-left of the grey bezel frame** (`#screen-container`) and remains subtly visible at all times.
- **Bottom Bezel Toolbar**: Relocated document title, auth, new draft, save to drive, and download buttons to the **bottom of the device bezel**.
- **Smooth Mouse & Idle Reveal**:
  - Toolbar expands/thickens smoothly when moving the mouse.
  - When mouse stops moving, controls hang around for 3 seconds before fading out.
  - Typing immediately fades out the toolbar for 100% distraction-free writing.
- **Accessibility Improvements**:
  - `:focus-visible` & `:focus-within` rules force controls to reveal when keyboard navigating with `Tab`.
  - Added `aria-live="polite"` for word count announcements.
  - Added `@media (prefers-reduced-motion: reduce)` rules.