### PR TITLE
fix: Slim bezel padding, narrow bottom status bar, absolute overlay for zero layout shift

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -51,17 +51,18 @@ body {
 
 #screen-container {
   background: linear-gradient(to bottom, var(--device-bezel), var(--device-bezel-dark));
-  border-radius: 20px;
-  padding: 20px 20px 0 20px;
+  border-radius: 16px;
+  padding: 12px 12px 0 12px;
   box-shadow: 
     0 8px 32px rgba(0,0,0,0.4),
     0 2px 8px rgba(0,0,0,0.2),
     inset 0 1px 0 rgba(255,255,255,0.15);
   width: 100%;
-  max-width: calc(var(--screen-max-width) + 48px);
+  max-width: calc(var(--screen-max-width) + 24px);
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 #etype-screen {
@@ -72,15 +73,17 @@ body {
   overflow-x: hidden;
   box-shadow: inset 0 2px 8px rgba(0,0,0,0.06), inset 0 0 0 1px rgba(0,0,0,0.04);
   position: relative;
+  flex-shrink: 0;
 }
 
 #device-footer {
-  padding: 12px 16px;
+  padding: 6px 12px 8px 12px;
   background: transparent;
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  transition: all 0.3s ease;
+  align-items: center;
+  justify-content: flex-start;
+  min-height: 30px;
+  position: relative;
 }
 
 .status-bar {
@@ -90,7 +93,7 @@ body {
 }
 
 #word-count {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   color: var(--toolbar-text);
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -100,16 +103,22 @@ body {
 }
 
 #toolbar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-top: 8px;
-  border-top: 1px solid rgba(0,0,0,0.08);
+  padding: 4px 12px;
+  background: linear-gradient(to bottom, var(--device-bezel), var(--device-bezel-dark));
+  border-radius: 0 0 16px 16px;
   opacity: 0;
   pointer-events: none;
-  max-height: 0;
-  overflow: hidden;
-  transition: opacity 0.3s ease, max-height 0.3s ease, padding 0.3s ease;
+  visibility: hidden;
+  transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1), visibility 0.4s ease;
+  z-index: 10;
 }
 
 body.show-controls #toolbar,
@@ -117,7 +126,7 @@ body.show-controls #toolbar,
 #toolbar:has(:focus-visible) {
   opacity: 1;
   pointer-events: auto;
-  max-height: 80px;
+  visibility: visible;
 }
 
 .toolbar-left {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -278,6 +278,7 @@ function init() {
     if (document.querySelector('dialog[open]')) return;
     const isInteractive = e.target.closest('button, input, select, textarea, a, label, dialog');
     if (!isInteractive) {
+      hideControlsImmediately();
       focusTypewriter();
     }
   });


### PR DESCRIPTION
## Summary
- **Slim Bezel**: Reduced side & top bezel padding (`padding: 12px 12px 0 12px`) for a refined, narrow Kindle/Kindle Scribe frame.
- **Narrow Bottom Status Bar**: Permanent bottom bezel area is narrow and contains only the word count in the bottom-left.
- **Zero Layout Shift**: The typing viewport (`#etype-screen`) is locked at `flex-shrink: 0; height: var(--screen-height);`. The bottom toolbar renders as an `absolute` overlay right over the bottom bezel when revealed. **The paper and text do not move or shift even 1 pixel when controls appear or disappear.**
- **Smooth Fade Transitions & Paper Click**: Applied `transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1)`. Clicking inside the paper typing area or typing any character immediately fades out the controls.