### PR TITLE
feat: Add setting toggle to show/hide word count in status bar (#22)

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -569,6 +569,31 @@ body.show-controls .floating-controls {
   font-size: 0.8rem;
 }
 
+.form-group-checkbox {
+  margin-top: 14px;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.85rem;
+  color: var(--ink-color);
+  cursor: pointer;
+  user-select: none;
+}
+
+.checkbox-label input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--ink-color);
+  cursor: pointer;
+}
+
+#word-count.hidden {
+  display: none !important;
+}
+
 @media (max-width: 640px) {
   body {
     align-items: flex-start;

--- a/public/index.html
+++ b/public/index.html
@@ -107,6 +107,12 @@
         <input type="text" id="settings-drive-folder" value="etype_drafts" autocomplete="off" spellcheck="false">
         <small class="field-help">Drafts will be saved to this folder in your Google Drive.</small>
       </div>
+      <div class="form-group form-group-checkbox">
+        <label class="checkbox-label" for="settings-show-wordcount">
+          <input type="checkbox" id="settings-show-wordcount" checked>
+          <span>Show word count in status bar</span>
+        </label>
+      </div>
       <div class="form-group">
         <label>Font & Aesthetic</label>
         <select id="settings-font-select" disabled>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -44,6 +44,7 @@ function init() {
   const closeInfoBtnEl = document.getElementById('btn-close-info');
   const settingsDialogEl = document.getElementById('settings-dialog');
   const settingsFolderInputEl = document.getElementById('settings-drive-folder');
+  const settingsWordCountInputEl = document.getElementById('settings-show-wordcount');
   const cancelSettingsBtnEl = document.getElementById('btn-cancel-settings');
   const saveSettingsBtnEl = document.getElementById('btn-save-settings');
 
@@ -76,11 +77,15 @@ function init() {
     closeInfoBtn: closeInfoBtnEl,
     settingsDialog: settingsDialogEl,
     settingsFolderInput: settingsFolderInputEl,
+    settingsWordCountInput: settingsWordCountInputEl,
     cancelSettingsBtn: cancelSettingsBtnEl,
     saveSettingsBtn: saveSettingsBtnEl,
     toast: toastEl,
     toastMessage: toastMessageEl,
   });
+
+  // Apply initial word count visibility setting
+  ui.setWordCountVisibility(appSettings.showWordCount !== false);
   
   // ---- Distraction-Free Controls & Bottom Bar Visibility ----
   let mouseIdleTimer = null;
@@ -180,7 +185,8 @@ function init() {
       ui.showSettingsDialog(appSettings, (newSettings) => {
         appSettings = newSettings;
         Storage.saveSettings(newSettings);
-        ui.showToast(`Settings saved. Folder: ${appSettings.driveFolder}`);
+        ui.setWordCountVisibility(appSettings.showWordCount !== false);
+        ui.showToast(`Settings saved.`);
       });
     },
 

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -56,13 +56,14 @@ export function saveSettings(settings) {
 export function loadSettings() {
   try {
     const raw = localStorage.getItem(SETTINGS_KEY);
-    if (!raw) return { driveFolder: 'etype_drafts' };
+    if (!raw) return { driveFolder: 'etype_drafts', showWordCount: true };
     const parsed = JSON.parse(raw);
     return {
-      driveFolder: parsed.driveFolder || 'etype_drafts'
+      driveFolder: parsed.driveFolder || 'etype_drafts',
+      showWordCount: parsed.showWordCount !== false,
     };
   } catch (e) {
-    return { driveFolder: 'etype_drafts' };
+    return { driveFolder: 'etype_drafts', showWordCount: true };
   }
 }
 

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -35,6 +35,7 @@ export class UI {
     this.closeInfoBtn = elements.closeInfoBtn;
     this.settingsDialog = elements.settingsDialog;
     this.settingsFolderInput = elements.settingsFolderInput;
+    this.settingsWordCountInput = elements.settingsWordCountInput;
     this.cancelSettingsBtn = elements.cancelSettingsBtn;
     this.saveSettingsBtn = elements.saveSettingsBtn;
     this.toast = elements.toast;
@@ -172,7 +173,7 @@ export class UI {
 
   /**
    * Show the Settings modal dialog.
-   * @param {Object} currentSettings - { driveFolder }
+   * @param {Object} currentSettings - { driveFolder, showWordCount }
    * @param {Function} onSave - Called with (newSettings)
    */
   showSettingsDialog(currentSettings, onSave) {
@@ -181,7 +182,23 @@ export class UI {
     if (this.settingsFolderInput) {
       this.settingsFolderInput.value = currentSettings.driveFolder || 'etype_drafts';
     }
+    if (this.settingsWordCountInput) {
+      this.settingsWordCountInput.checked = currentSettings.showWordCount !== false;
+    }
     this.settingsDialog.showModal();
+  }
+
+  /**
+   * Toggle visibility of the word count in the status bar.
+   * @param {boolean} visible
+   */
+  setWordCountVisibility(visible) {
+    if (!this.wordCount) return;
+    if (visible) {
+      this.wordCount.classList.remove('hidden');
+    } else {
+      this.wordCount.classList.add('hidden');
+    }
   }
 
   /**
@@ -208,7 +225,7 @@ export class UI {
    * @param {Function} handlers.onGDrive - Called when "Save to Google Drive" button clicked
    * @param {Function} handlers.onTitleChange - Called when title input changes
    * @param {Function} handlers.onAuth - Called when auth button clicked
-   * @param {Function} handlers.onSaveSettings - Called with ({ driveFolder })
+   * @param {Function} handlers.onSaveSettings - Called with ({ driveFolder, showWordCount })
    */
   bindHandlers(handlers) {
     // Auth button
@@ -253,11 +270,12 @@ export class UI {
     if (this.saveSettingsBtn && this.settingsDialog) {
       this.saveSettingsBtn.addEventListener('click', () => {
         const driveFolder = (this.settingsFolderInput ? this.settingsFolderInput.value : '').trim() || 'etype_drafts';
+        const showWordCount = this.settingsWordCountInput ? this.settingsWordCountInput.checked : true;
         const cb = this._onSaveSettingsConfirm;
         this._onSaveSettingsConfirm = null;
         this.settingsDialog.close();
         if (cb) {
-          cb({ driveFolder });
+          cb({ driveFolder, showWordCount });
         }
       });
     }


### PR DESCRIPTION
## Summary
- **Settings Toggle**: Added a checkbox in the Settings (`⚙`) dialog: **"Show word count in status bar"** (default: checked).
- **Persistence**: Preference is saved in `localStorage` (`showWordCount: boolean`).
- **Real-Time Toggle**: Toggling the checkbox in Settings immediately hides or shows the word count status indicator in the bottom-left of the bezel without page reloads.