### PR TITLE
docs: Update text in the information panel (#23)

### DIFF
--- a/docs/about.txt
+++ b/docs/about.txt
@@ -1,11 +1,11 @@
-There's a theory that there are two stages to writing.
-
-First drafts, where you get everything out without overthinking, and editing, where you can overthink as much as you want
+There's a theory that there are two stages to writing: first drafts, where you get everything out without overthinking, and editing, where you can overthink as much as you want.
 
 This app is for first drafts.
 
-Log in with your Google ID, give it permission to save things to a folder in your Google Drive. (That's all it does. All the code for this is in your browser, and you can see the app in the repo here.)
+You can use this without an account and just download the draft at any time.
 
-You can't backspace, you can't delete, you can't move the cursor around. It's a typewriter. Write your draft, save it to Google Drive, and then edit it there.
+Or you can log in with your Google ID and give it permission to save things to a folder in your Google Drive. (That's all it does. All the code for this is visible in your browser, and you can examine it in the repo linked below.)
+
+But you can't backspace, you can't delete, you can't move the cursor around. It's a typewriter. Write your draft, save it to Google Drive, and edit it there.
 
 Enjoy.

--- a/public/index.html
+++ b/public/index.html
@@ -87,8 +87,9 @@
       <h2>About E-Type</h2>
       <p>There's a theory that there are two stages to writing: <strong>first drafts</strong>, where you get everything out without overthinking, and <strong>editing</strong>, where you can overthink as much as you want.</p>
       <p>This app is for first drafts.</p>
-      <p>Log in with your Google ID and give it permission to save things to a folder in your Google Drive. (That's all it does. All the code for this is in your browser.)</p>
-      <p>You can't backspace, you can't delete, you can't move the cursor around. It's a typewriter. Write your draft, save it to Google Drive, and edit it there.</p>
+      <p>You can use this without an account and just download the draft at any time.</p>
+      <p>Or you can log in with your Google ID and give it permission to save things to a folder in your Google Drive. (That's all it does. All the code for this is visible in your browser, and you can examine it in the repo linked below.)</p>
+      <p>But you can't backspace, you can't delete, you can't move the cursor around. It's a typewriter. Write your draft, save it to Google Drive, and edit it there.</p>
       <p>Enjoy.</p>
       <div class="dialog-footer-links">
         <a href="https://github.com/grahamsw/etype-emulator" target="_blank" rel="noopener">View Source on GitHub ↗</a>


### PR DESCRIPTION
Closes #23

## Summary
- Updated the text in the **About E-Type** info dialog (`#info-dialog` in `public/index.html`).
- Clarified that the app can be used offline without an account to download drafts.
- Updated Google Drive sign-in explanation and source code reference.
- Synchronized `docs/about.txt` with the updated copy.