### PR TITLE
feat: Add Copy Contents button to bottom action toolbar and Ctrl+C / Cmd+C shortcut (#25)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,6 +34,9 @@
             <button id="btn-new" type="button" title="New Draft" aria-label="New Draft">
               <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="10" y1="4" x2="10" y2="16"/><line x1="4" y1="10" x2="16" y2="10"/></svg>
             </button>
+            <button id="btn-copy" type="button" title="Copy to Clipboard (Ctrl+C / Cmd+C)" aria-label="Copy to Clipboard (Ctrl+C / Cmd+C)">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+            </button>
             <button id="btn-gdrive" type="button" title="Save to Google Drive" aria-label="Save to Google Drive">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 18a3.5 3.5 0 0 0 0-7h-1A5 5 0 0 0 7 9a3.5 3.5 0 0 0 0 7h12z"/><path d="M12 12v6"/><path d="m15 15-3-3-3 3"/></svg>
             </button>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -27,6 +27,7 @@ function init() {
   const authBtnEl = document.getElementById('btn-auth');
   const gdriveBtnEl = document.getElementById('btn-gdrive');
   const newBtnEl = document.getElementById('btn-new');
+  const copyBtnEl = document.getElementById('btn-copy');
   const downloadBtnEl = document.getElementById('btn-download');
   const dialogEl = document.getElementById('new-draft-dialog');
   const confirmBtnEl = document.getElementById('btn-confirm-new');
@@ -62,6 +63,7 @@ function init() {
     authBtn: authBtnEl,
     gdriveBtn: gdriveBtnEl,
     newBtn: newBtnEl,
+    copyBtn: copyBtnEl,
     downloadBtn: downloadBtnEl,
     dialog: dialogEl,
     confirmBtn: confirmBtnEl,
@@ -131,6 +133,21 @@ function init() {
     });
   }, 1500);
   
+  // ---- Copy to Clipboard Handler ----
+  const handleCopy = async () => {
+    const text = typewriter.getText();
+    if (!text) {
+      ui.showToast('Draft is empty');
+      return;
+    }
+    const success = await Storage.copyToClipboard(text);
+    if (success) {
+      ui.showToast('Copied draft to clipboard!');
+    } else {
+      ui.showToast('Failed to copy to clipboard');
+    }
+  };
+
   // ---- Initialize Typewriter ----
   const typewriter = new Typewriter(displayEl, inputEl, cursorEl, {
     onTextChange: (text) => {
@@ -139,6 +156,9 @@ function init() {
     },
     onTypingStart: () => {
       hideControlsImmediately();
+    },
+    onCopyRequest: () => {
+      handleCopy();
     },
   });
   
@@ -255,6 +275,10 @@ function init() {
         Storage.clearStorage();
         typewriter.focus();
       }
+    },
+
+    onCopy: () => {
+      handleCopy();
     },
     
     onDownload: () => {

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -113,3 +113,32 @@ function sanitizeFilename(name) {
     .replace(/-+/g, '-')
     .slice(0, 60) || 'draft';
 }
+
+/**
+ * Copy text to system clipboard.
+ * @param {string} text
+ * @returns {Promise<boolean>}
+ */
+export async function copyToClipboard(text) {
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch (err) {
+    // Fallback below
+  }
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const success = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return success;
+  } catch (e) {
+    return false;
+  }
+}

--- a/public/js/typewriter.js
+++ b/public/js/typewriter.js
@@ -19,6 +19,7 @@ export class Typewriter {
     this.onTextChange = options.onTextChange || null;
     this.onFirstChar = options.onFirstChar || null;
     this.onTypingStart = options.onTypingStart || null;
+    this.onCopyRequest = options.onCopyRequest || null;
     
     this.text = '';           // canonical text buffer (append-only during typing)
     this.queue = [];          // characters waiting to be rendered
@@ -60,6 +61,15 @@ export class Typewriter {
   // ---- Key Blocking ----
   
   _onKeyDown(e) {
+    // Ctrl/Cmd + C (Copy draft to clipboard)
+    if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key.toLowerCase() === 'c') {
+      e.preventDefault();
+      if (this.onCopyRequest) {
+        this.onCopyRequest();
+      }
+      return;
+    }
+
     if (this.onTypingStart) {
       this.onTypingStart();
     }

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -17,6 +17,7 @@ export class UI {
     this.wordCount = elements.wordCount;
     this.titleInput = elements.titleInput;
     this.newBtn = elements.newBtn;
+    this.copyBtn = elements.copyBtn;
     this.downloadBtn = elements.downloadBtn;
     this.gdriveBtn = elements.gdriveBtn;
     this.authBtn = elements.authBtn;
@@ -301,6 +302,13 @@ export class UI {
       if (handlers.onNew) handlers.onNew();
     });
     
+    // Copy button
+    if (this.copyBtn) {
+      this.copyBtn.addEventListener('click', () => {
+        if (handlers.onCopy) handlers.onCopy();
+      });
+    }
+
     // Download button
     this.downloadBtn.addEventListener('click', () => {
       if (handlers.onDownload) handlers.onDownload();


### PR DESCRIPTION
Closes #25

## Summary
- **Copy Button**: Added a Copy button (`#btn-copy`) with inline SVG clipboard icon to the bottom action toolbar (`#toolbar`).
- **Tooltip**: Set button tooltip and aria-label to `Copy to Clipboard (Ctrl+C / Cmd+C)`.
- **Action & Toast**: Clicking the button copies the canonical text of the typewriter draft to system clipboard (`navigator.clipboard.writeText`) and displays a floating toast notification `Copied draft to clipboard!`.
- **Keyboard Shortcut**: Pressing `Ctrl+C` or `Cmd+C` while typing or focused on the app intercepts the shortcut to copy the text to clipboard and trigger the toast notification.