### PR TITLE
feat: Add filename timestamp settings and Google Drive subfolder path support (#27)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -77,6 +77,7 @@
       <div class="form-group">
         <label for="gdrive-title-input">Document Title</label>
         <input type="text" id="gdrive-title-input" autocomplete="off" spellcheck="false">
+        <small class="field-help">You can include subfolders, e.g. <code>old man/and the sea</code></small>
       </div>
       <div class="dialog-actions">
         <button id="btn-cancel-gdrive" type="button" class="btn-secondary">Cancel</button>
@@ -116,6 +117,28 @@
           <input type="checkbox" id="settings-show-wordcount" checked>
           <span>Show word count in status bar</span>
         </label>
+      </div>
+      <div class="form-group form-group-checkbox">
+        <label class="checkbox-label" for="settings-enable-timestamp">
+          <input type="checkbox" id="settings-enable-timestamp" checked>
+          <span>Add timestamp to saved filenames</span>
+        </label>
+      </div>
+      <div class="form-group">
+        <label for="settings-timestamp-format">Timestamp Format</label>
+        <select id="settings-timestamp-format">
+          <option value="YYYY-MM-DD HH-mm">2026-08-17 12-02 (Default)</option>
+          <option value="YYYY-MM-DD">2026-08-17 (Date only)</option>
+          <option value="YYYYMMDD-HHmm">20260817-1202 (Compact)</option>
+          <option value="ISO">2026-08-17T12-02 (ISO style)</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="settings-timestamp-position">Timestamp Position</label>
+        <select id="settings-timestamp-position">
+          <option value="after">After Title (title-2026-08-17 12-02.md)</option>
+          <option value="before">Before Title (2026-08-17 12-02-title.md)</option>
+        </select>
       </div>
       <div class="form-group">
         <label>Font & Aesthetic</label>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -46,6 +46,9 @@ function init() {
   const settingsDialogEl = document.getElementById('settings-dialog');
   const settingsFolderInputEl = document.getElementById('settings-drive-folder');
   const settingsWordCountInputEl = document.getElementById('settings-show-wordcount');
+  const settingsEnableTimestampInputEl = document.getElementById('settings-enable-timestamp');
+  const settingsTimestampFormatSelectEl = document.getElementById('settings-timestamp-format');
+  const settingsTimestampPositionSelectEl = document.getElementById('settings-timestamp-position');
   const cancelSettingsBtnEl = document.getElementById('btn-cancel-settings');
   const saveSettingsBtnEl = document.getElementById('btn-save-settings');
 
@@ -80,6 +83,9 @@ function init() {
     settingsDialog: settingsDialogEl,
     settingsFolderInput: settingsFolderInputEl,
     settingsWordCountInput: settingsWordCountInputEl,
+    settingsEnableTimestampInput: settingsEnableTimestampInputEl,
+    settingsTimestampFormatSelect: settingsTimestampFormatSelectEl,
+    settingsTimestampPositionSelect: settingsTimestampPositionSelectEl,
     cancelSettingsBtn: cancelSettingsBtnEl,
     saveSettingsBtn: saveSettingsBtnEl,
     toast: toastEl,
@@ -243,11 +249,11 @@ function init() {
       // Open Save to Google Drive modal dialog
       ui.showGDriveDialog(ui.getTitle(), folderName, async (customTitle) => {
         try {
-          ui.showToast(`Saving to ${folderName} folder in Google Drive...`);
+          ui.showToast(`Saving to Google Drive...`);
           const activeToken = getAccessToken() || token;
-          const file = await saveDraftToDrive(activeToken, customTitle, text, folderName);
+          const file = await saveDraftToDrive(activeToken, customTitle, text, folderName, appSettings);
           ui.setTitle(customTitle);
-          ui.showToast(`Saved "${file.name}" to ${folderName} in Google Drive!`);
+          ui.showToast(`Saved "${file.name}" to Google Drive!`);
         } catch (err) {
           console.error('Google Drive save error:', err);
           ui.showToast(`Drive Error: ${err.message || 'Failed to save'}`);
@@ -285,7 +291,7 @@ function init() {
       const text = typewriter.getText();
       const title = ui.getTitle();
       if (!text.trim()) return; // Nothing to download
-      Storage.downloadAsMarkdown(text, title);
+      Storage.downloadAsMarkdown(text, title, appSettings);
     },
     
     onTitleChange: () => {

--- a/public/js/drive.js
+++ b/public/js/drive.js
@@ -1,6 +1,7 @@
 // drive.js — Google Drive API integration for etype_drafts folder and uploads
 
 import { clearAccessToken } from './auth.js';
+import { processFilename } from './storage.js';
 
 const DRIVE_API_BASE = 'https://www.googleapis.com/drive/v3';
 const UPLOAD_API_BASE = 'https://www.googleapis.com/upload/drive/v3';
@@ -10,89 +11,100 @@ let cachedFolderId = null;
 let cachedFolderName = null;
 
 /**
- * Searches for the specified folder in the user's Google Drive.
- * Creates it if it does not exist.
+ * Searches for or creates a nested folder path in Google Drive.
+ * e.g. "Hemingway/old man" -> creates "Hemingway" then "old man" inside it.
  * @param {string} accessToken - Google OAuth Access Token
- * @param {string} [folderName='etype_drafts'] - Target folder name
- * @returns {Promise<string>} Google Drive Folder ID
+ * @param {string} [folderPath='etype_drafts'] - Folder path
+ * @returns {Promise<string>} Google Drive Folder ID of the deepest folder
  */
-export async function getOrCreateDraftsFolder(accessToken, folderName = FOLDER_NAME) {
-  const targetFolder = folderName.trim() || FOLDER_NAME;
-  if (cachedFolderId && cachedFolderName === targetFolder) return cachedFolderId;
+export async function getOrCreateDraftsFolder(accessToken, folderPath = FOLDER_NAME) {
+  const normalizedPath = (folderPath || FOLDER_NAME).replace(/\\/g, '/').trim();
+  const folderParts = normalizedPath.split('/').map(p => p.trim()).filter(Boolean);
+
+  if (folderParts.length === 0) folderParts.push(FOLDER_NAME);
 
   if (!accessToken) {
     throw new Error('No Google access token available. Please sign in with Google.');
   }
 
-  // 1. Search for existing folder
-  const query = encodeURIComponent(`name='${targetFolder}' and mimeType='application/vnd.google-apps.folder' and trashed=false`);
-  const searchUrl = `${DRIVE_API_BASE}/files?q=${query}&fields=files(id,name)`;
+  let currentParentId = 'root';
 
-  const response = await fetch(searchUrl, {
-    headers: {
-      'Authorization': `Bearer ${accessToken}`
+  for (const folderName of folderParts) {
+    const query = encodeURIComponent(`name='${folderName}' and '${currentParentId}' in parents and mimeType='application/vnd.google-apps.folder' and trashed=false`);
+    const searchUrl = `${DRIVE_API_BASE}/files?q=${query}&fields=files(id,name)`;
+
+    const response = await fetch(searchUrl, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`
+      }
+    });
+
+    if (response.status === 401) {
+      clearAccessToken();
+      resetDriveCache();
+      throw new Error('Google authorization expired. Please sign in again.');
     }
-  });
 
-  if (response.status === 401) {
-    clearAccessToken();
-    resetDriveCache();
-    throw new Error('Google authorization expired. Please sign in again.');
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(`Google Drive API error (${response.status}): ${errText}`);
+    }
+
+    const data = await response.json();
+    if (data.files && data.files.length > 0) {
+      currentParentId = data.files[0].id;
+    } else {
+      // Create folder under currentParentId
+      const bodyPayload = {
+        name: folderName,
+        mimeType: 'application/vnd.google-apps.folder'
+      };
+      if (currentParentId !== 'root') {
+        bodyPayload.parents = [currentParentId];
+      }
+
+      const createResponse = await fetch(`${DRIVE_API_BASE}/files`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(bodyPayload)
+      });
+
+      if (createResponse.status === 401) {
+        clearAccessToken();
+        resetDriveCache();
+        throw new Error('Google authorization expired. Please sign in again.');
+      }
+
+      if (!createResponse.ok) {
+        const errText = await createResponse.text();
+        throw new Error(`Google Drive API error (${createResponse.status}): ${errText}`);
+      }
+
+      const createdData = await createResponse.json();
+      currentParentId = createdData.id;
+    }
   }
 
-  if (!response.ok) {
-    const errText = await response.text();
-    throw new Error(`Google Drive API error (${response.status}): ${errText}`);
-  }
-
-  const data = await response.json();
-  if (data.files && data.files.length > 0) {
-    cachedFolderId = data.files[0].id;
-    cachedFolderName = targetFolder;
-    return cachedFolderId;
-  }
-
-  // 2. Create the folder if missing
-  const createResponse = await fetch(`${DRIVE_API_BASE}/files`, {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      name: targetFolder,
-      mimeType: 'application/vnd.google-apps.folder'
-    })
-  });
-
-  if (createResponse.status === 401) {
-    clearAccessToken();
-    resetDriveCache();
-    throw new Error('Google authorization expired. Please sign in again.');
-  }
-
-  if (!createResponse.ok) {
-    const errText = await createResponse.text();
-    throw new Error(`Failed to create '${targetFolder}' folder in Google Drive: ${errText}`);
-  }
-
-  const createdFolder = await createResponse.json();
-  cachedFolderId = createdFolder.id;
-  cachedFolderName = targetFolder;
-  return cachedFolderId;
+  return currentParentId;
 }
 
 /**
  * Saves a markdown draft to Google Drive.
  * @param {string} accessToken - Google OAuth Access Token
- * @param {string} title - File title/name
+ * @param {string} title - File title/path (can contain subfolders, e.g. "old man/and the sea")
  * @param {string} content - Markdown draft content
- * @param {string} [folderName='etype_drafts'] - Target folder name
+ * @param {string} [rootFolderName='etype_drafts'] - Root folder name from settings
+ * @param {Object} [settings] - App settings for timestamp formatting
  * @returns {Promise<{id: string, name: string, webViewLink: string}>} Uploaded file details
  */
-export async function saveDraftToDrive(accessToken, title, content, folderName = FOLDER_NAME) {
-  const folderId = await getOrCreateDraftsFolder(accessToken, folderName);
-  const filename = (title.trim() || 'Untitled Draft') + '.md';
+export async function saveDraftToDrive(accessToken, title, content, rootFolderName = FOLDER_NAME, settings = {}) {
+  const { subfolderPath, filename } = processFilename(title, settings);
+  const targetFolderPath = [rootFolderName, subfolderPath].filter(Boolean).join('/');
+
+  const folderId = await getOrCreateDraftsFolder(accessToken, targetFolderPath);
 
   const metadata = {
     name: filename,

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -56,14 +56,31 @@ export function saveSettings(settings) {
 export function loadSettings() {
   try {
     const raw = localStorage.getItem(SETTINGS_KEY);
-    if (!raw) return { driveFolder: 'etype_drafts', showWordCount: true };
+    if (!raw) {
+      return {
+        driveFolder: 'etype_drafts',
+        showWordCount: true,
+        enableTimestamp: true,
+        timestampFormat: 'YYYY-MM-DD HH-mm',
+        timestampPosition: 'after',
+      };
+    }
     const parsed = JSON.parse(raw);
     return {
       driveFolder: parsed.driveFolder || 'etype_drafts',
       showWordCount: parsed.showWordCount !== false,
+      enableTimestamp: parsed.enableTimestamp !== false,
+      timestampFormat: parsed.timestampFormat || 'YYYY-MM-DD HH-mm',
+      timestampPosition: parsed.timestampPosition || 'after',
     };
   } catch (e) {
-    return { driveFolder: 'etype_drafts', showWordCount: true };
+    return {
+      driveFolder: 'etype_drafts',
+      showWordCount: true,
+      enableTimestamp: true,
+      timestampFormat: 'YYYY-MM-DD HH-mm',
+      timestampPosition: 'after',
+    };
   }
 }
 
@@ -79,12 +96,90 @@ export function clearStorage() {
 }
 
 /**
+ * Format a Date object according to chosen format.
+ * @param {Date} [date=new Date()]
+ * @param {string} [format='YYYY-MM-DD HH-mm']
+ * @returns {string}
+ */
+export function formatFormattedTimestamp(date = new Date(), format = 'YYYY-MM-DD HH-mm') {
+  const d = date instanceof Date ? date : new Date(date);
+  const pad = (n) => String(n).padStart(2, '0');
+
+  const year = d.getFullYear();
+  const month = pad(d.getMonth() + 1);
+  const day = pad(d.getDate());
+  const hours = pad(d.getHours());
+  const minutes = pad(d.getMinutes());
+
+  switch (format) {
+    case 'YYYY-MM-DD':
+      return `${year}-${month}-${day}`;
+    case 'YYYYMMDD-HHmm':
+      return `${year}${month}${day}-${hours}${minutes}`;
+    case 'ISO':
+      return `${year}-${month}-${day}T${hours}-${minutes}`;
+    case 'YYYY-MM-DD HH-mm':
+    default:
+      return `${year}-${month}-${day} ${hours}-${minutes}`;
+  }
+}
+
+/**
+ * Parse raw title/path and format filename & subfolder.
+ * @param {string} rawPath - e.g. "old man/and the sea" or "untitled"
+ * @param {Object} [settings] - App settings
+ * @param {Date} [date=new Date()]
+ * @returns {{ subfolderPath: string, cleanTitle: string, filename: string }}
+ */
+export function processFilename(rawPath, settings = {}, date = new Date()) {
+  const currentSettings = {
+    enableTimestamp: true,
+    timestampFormat: 'YYYY-MM-DD HH-mm',
+    timestampPosition: 'after',
+    ...settings,
+  };
+
+  const normalized = (rawPath || 'untitled-draft').replace(/\\/g, '/').trim();
+  const parts = normalized.split('/').map(p => p.trim()).filter(Boolean);
+
+  let rawTitle = 'untitled-draft';
+  let subfolderParts = [];
+
+  if (parts.length > 1) {
+    rawTitle = parts[parts.length - 1];
+    subfolderParts = parts.slice(0, parts.length - 1);
+  } else if (parts.length === 1) {
+    rawTitle = parts[0];
+  }
+
+  const cleanTitle = sanitizeFilename(rawTitle) || 'draft';
+  const subfolderPath = subfolderParts.join('/');
+
+  let nameWithoutExt = cleanTitle;
+  if (currentSettings.enableTimestamp) {
+    const ts = formatFormattedTimestamp(date, currentSettings.timestampFormat);
+    if (currentSettings.timestampPosition === 'before') {
+      nameWithoutExt = `${ts}-${cleanTitle}`;
+    } else {
+      nameWithoutExt = `${cleanTitle}-${ts}`;
+    }
+  }
+
+  return {
+    subfolderPath,
+    cleanTitle,
+    filename: `${nameWithoutExt}.md`,
+  };
+}
+
+/**
  * Download text as a markdown (.md) file.
  * @param {string} text - The markdown content.
  * @param {string} title - Used for the filename.
+ * @param {Object} [settings] - App settings for timestamp formatting
  */
-export function downloadAsMarkdown(text, title) {
-  const filename = sanitizeFilename(title || 'untitled-draft') + '.md';
+export function downloadAsMarkdown(text, title, settings = {}) {
+  const { filename } = processFilename(title, settings);
   const blob = new Blob([text], { type: 'text/markdown;charset=utf-8' });
   const url = URL.createObjectURL(blob);
   

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -37,6 +37,9 @@ export class UI {
     this.settingsDialog = elements.settingsDialog;
     this.settingsFolderInput = elements.settingsFolderInput;
     this.settingsWordCountInput = elements.settingsWordCountInput;
+    this.settingsEnableTimestampInput = elements.settingsEnableTimestampInput;
+    this.settingsTimestampFormatSelect = elements.settingsTimestampFormatSelect;
+    this.settingsTimestampPositionSelect = elements.settingsTimestampPositionSelect;
     this.cancelSettingsBtn = elements.cancelSettingsBtn;
     this.saveSettingsBtn = elements.saveSettingsBtn;
     this.toast = elements.toast;
@@ -174,7 +177,7 @@ export class UI {
 
   /**
    * Show the Settings modal dialog.
-   * @param {Object} currentSettings - { driveFolder, showWordCount }
+   * @param {Object} currentSettings - { driveFolder, showWordCount, enableTimestamp, timestampFormat, timestampPosition }
    * @param {Function} onSave - Called with (newSettings)
    */
   showSettingsDialog(currentSettings, onSave) {
@@ -185,6 +188,15 @@ export class UI {
     }
     if (this.settingsWordCountInput) {
       this.settingsWordCountInput.checked = currentSettings.showWordCount !== false;
+    }
+    if (this.settingsEnableTimestampInput) {
+      this.settingsEnableTimestampInput.checked = currentSettings.enableTimestamp !== false;
+    }
+    if (this.settingsTimestampFormatSelect) {
+      this.settingsTimestampFormatSelect.value = currentSettings.timestampFormat || 'YYYY-MM-DD HH-mm';
+    }
+    if (this.settingsTimestampPositionSelect) {
+      this.settingsTimestampPositionSelect.value = currentSettings.timestampPosition || 'after';
     }
     this.settingsDialog.showModal();
   }
@@ -272,11 +284,21 @@ export class UI {
       this.saveSettingsBtn.addEventListener('click', () => {
         const driveFolder = (this.settingsFolderInput ? this.settingsFolderInput.value : '').trim() || 'etype_drafts';
         const showWordCount = this.settingsWordCountInput ? this.settingsWordCountInput.checked : true;
+        const enableTimestamp = this.settingsEnableTimestampInput ? this.settingsEnableTimestampInput.checked : true;
+        const timestampFormat = this.settingsTimestampFormatSelect ? this.settingsTimestampFormatSelect.value : 'YYYY-MM-DD HH-mm';
+        const timestampPosition = this.settingsTimestampPositionSelect ? this.settingsTimestampPositionSelect.value : 'after';
+
         const cb = this._onSaveSettingsConfirm;
         this._onSaveSettingsConfirm = null;
         this.settingsDialog.close();
         if (cb) {
-          cb({ driveFolder, showWordCount });
+          cb({
+            driveFolder,
+            showWordCount,
+            enableTimestamp,
+            timestampFormat,
+            timestampPosition,
+          });
         }
       });
     }


### PR DESCRIPTION
Closes #27

## Summary
- **Timestamp Settings**: Added configurable timestamp options in Settings (`⚙`):
  - Toggle to enable/disable timestamps on saved filenames (default: enabled).
  - Format choices: `YYYY-MM-DD HH-mm` (default, e.g. `2026-08-17 12-02`), `YYYY-MM-DD`, `YYYYMMDD-HHmm`, `ISO`.
  - Position choices: After title (`title-2026-08-17 12-02.md`) or Before title (`2026-08-17 12-02-title.md`).
- **Google Drive Subfolder Path Support**:
  - Entering a path with slashes or backslashes in the save dialog or title (e.g. `old man/and the sea` or `old man\and the sea`) automatically parses the subfolder path (`old man`) and file title (`and the sea`).
  - Google Drive integration recursively searches for / creates nested folder paths (e.g. `[Root]/old man/`) and saves the timestamped file inside the target subfolder.