### PR TITLE
feat: Add daily sequential versioning (2026-08-17.1, 2026-08-17.2) with zero new permissions (#29)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -128,6 +128,7 @@
         <label for="settings-timestamp-format">Timestamp Format</label>
         <select id="settings-timestamp-format">
           <option value="YYYY-MM-DD HH-mm">2026-08-17 12-02 (Default)</option>
+          <option value="YYYY-MM-DD.seq">2026-08-17.1, .2 (Date + daily sequence)</option>
           <option value="YYYY-MM-DD">2026-08-17 (Date only)</option>
           <option value="YYYYMMDD-HHmm">20260817-1202 (Compact)</option>
           <option value="ISO">2026-08-17T12-02 (ISO style)</option>

--- a/public/js/drive.js
+++ b/public/js/drive.js
@@ -92,6 +92,51 @@ export async function getOrCreateDraftsFolder(accessToken, folderPath = FOLDER_N
 }
 
 /**
+ * Queries Google Drive folder for files created today and computes the next sequence number.
+ * Uses existing drive.file scope with zero new permissions.
+ * @param {string} accessToken
+ * @param {string} folderId
+ * @param {string} cleanTitle
+ * @param {string} dateStr - e.g. "2026-08-17"
+ * @returns {Promise<number>} Next sequence number
+ */
+async function getNextDriveSequence(accessToken, folderId, cleanTitle, dateStr) {
+  try {
+    const query = encodeURIComponent(`'${folderId}' in parents and mimeType != 'application/vnd.google-apps.folder' and trashed=false`);
+    const searchUrl = `${DRIVE_API_BASE}/files?q=${query}&fields=files(id,name)`;
+
+    const response = await fetch(searchUrl, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`
+      }
+    });
+
+    if (!response.ok) return 1;
+
+    const data = await response.json();
+    if (!data.files || data.files.length === 0) return 1;
+
+    let maxSeq = 0;
+    const targetPattern = `${dateStr}.`;
+
+    for (const file of data.files) {
+      const name = file.name || '';
+      if (name.includes(targetPattern) && name.includes(cleanTitle)) {
+        const match = name.match(new RegExp(`${dateStr}\\.(\\d+)`));
+        if (match && match[1]) {
+          const num = parseInt(match[1], 10);
+          if (num > maxSeq) maxSeq = num;
+        }
+      }
+    }
+
+    return maxSeq + 1;
+  } catch (e) {
+    return 1;
+  }
+}
+
+/**
  * Saves a markdown draft to Google Drive.
  * @param {string} accessToken - Google OAuth Access Token
  * @param {string} title - File title/path (can contain subfolders, e.g. "old man/and the sea")
@@ -101,10 +146,26 @@ export async function getOrCreateDraftsFolder(accessToken, folderPath = FOLDER_N
  * @returns {Promise<{id: string, name: string, webViewLink: string}>} Uploaded file details
  */
 export async function saveDraftToDrive(accessToken, title, content, rootFolderName = FOLDER_NAME, settings = {}) {
-  const { subfolderPath, filename } = processFilename(title, settings);
+  const normalizedPath = (title || 'untitled-draft').replace(/\\/g, '/').trim();
+  const parts = normalizedPath.split('/').map(p => p.trim()).filter(Boolean);
+  const rawTitle = parts.length > 0 ? parts[parts.length - 1] : 'untitled-draft';
+  const subfolderParts = parts.length > 1 ? parts.slice(0, parts.length - 1) : [];
+
+  const subfolderPath = subfolderParts.join('/');
   const targetFolderPath = [rootFolderName, subfolderPath].filter(Boolean).join('/');
 
   const folderId = await getOrCreateDraftsFolder(accessToken, targetFolderPath);
+
+  let seqNum = null;
+  if (settings && settings.enableTimestamp && settings.timestampFormat === 'YYYY-MM-DD.seq') {
+    const d = new Date();
+    const pad = (n) => String(n).padStart(2, '0');
+    const dateStr = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+    const cleanTitle = rawTitle.toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').slice(0, 60) || 'draft';
+    seqNum = await getNextDriveSequence(accessToken, folderId, cleanTitle, dateStr);
+  }
+
+  const { filename } = processFilename(title, settings, new Date(), seqNum);
 
   const metadata = {
     name: filename,

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -96,12 +96,31 @@ export function clearStorage() {
 }
 
 /**
+ * Track and increment daily download sequence counter in localStorage.
+ * @param {string} titleKey
+ * @param {string} dateStr
+ * @returns {number} Next sequence number
+ */
+export function getAndIncrementLocalSequence(titleKey, dateStr) {
+  try {
+    const key = `etype-seq-${dateStr}-${titleKey}`;
+    const current = parseInt(localStorage.getItem(key) || '0', 10);
+    const next = current + 1;
+    localStorage.setItem(key, String(next));
+    return next;
+  } catch (e) {
+    return 1;
+  }
+}
+
+/**
  * Format a Date object according to chosen format.
  * @param {Date} [date=new Date()]
  * @param {string} [format='YYYY-MM-DD HH-mm']
+ * @param {number|null} [seqNum=null]
  * @returns {string}
  */
-export function formatFormattedTimestamp(date = new Date(), format = 'YYYY-MM-DD HH-mm') {
+export function formatFormattedTimestamp(date = new Date(), format = 'YYYY-MM-DD HH-mm', seqNum = null) {
   const d = date instanceof Date ? date : new Date(date);
   const pad = (n) => String(n).padStart(2, '0');
 
@@ -112,6 +131,8 @@ export function formatFormattedTimestamp(date = new Date(), format = 'YYYY-MM-DD
   const minutes = pad(d.getMinutes());
 
   switch (format) {
+    case 'YYYY-MM-DD.seq':
+      return `${year}-${month}-${day}.${seqNum || 1}`;
     case 'YYYY-MM-DD':
       return `${year}-${month}-${day}`;
     case 'YYYYMMDD-HHmm':
@@ -129,9 +150,10 @@ export function formatFormattedTimestamp(date = new Date(), format = 'YYYY-MM-DD
  * @param {string} rawPath - e.g. "old man/and the sea" or "untitled"
  * @param {Object} [settings] - App settings
  * @param {Date} [date=new Date()]
+ * @param {number|null} [overrideSeq=null] - Sequence number override
  * @returns {{ subfolderPath: string, cleanTitle: string, filename: string }}
  */
-export function processFilename(rawPath, settings = {}, date = new Date()) {
+export function processFilename(rawPath, settings = {}, date = new Date(), overrideSeq = null) {
   const currentSettings = {
     enableTimestamp: true,
     timestampFormat: 'YYYY-MM-DD HH-mm',
@@ -157,7 +179,14 @@ export function processFilename(rawPath, settings = {}, date = new Date()) {
 
   let nameWithoutExt = cleanTitle;
   if (currentSettings.enableTimestamp) {
-    const ts = formatFormattedTimestamp(date, currentSettings.timestampFormat);
+    let seqNum = overrideSeq;
+    if (currentSettings.timestampFormat === 'YYYY-MM-DD.seq' && seqNum === null) {
+      const pad = (n) => String(n).padStart(2, '0');
+      const dateStr = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+      seqNum = getAndIncrementLocalSequence(cleanTitle, dateStr);
+    }
+
+    const ts = formatFormattedTimestamp(date, currentSettings.timestampFormat, seqNum);
     if (currentSettings.timestampPosition === 'before') {
       nameWithoutExt = `${ts}-${cleanTitle}`;
     } else {


### PR DESCRIPTION
Closes #29

## Summary
- **Zero New Permissions**: Uses the existing `https://www.googleapis.com/auth/drive.file` OAuth scope to query target Google Drive folders created by E-Type.
- **Daily Sequential Versioning**: Added **`2026-08-17.1, .2 (Date + daily sequence)`** format choice in Settings (`⚙`):
  - Google Drive saves query the folder for existing files created today and automatically increment sequence numbers (e.g. `and-the-sea-2026-08-17.1.md`, `and-the-sea-2026-08-17.2.md`).
  - Local browser downloads track daily sequence counters in `localStorage` per date and draft title.