### PR TITLE
feat: Add customizable font family choices, font sizes, and persistence (#31)

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -226,8 +226,8 @@ body.show-controls #toolbar,
 
 #text-display {
   padding: 28px 32px;
-  font-family: var(--font-mono);
-  font-size: 1.05rem;
+  font-family: var(--active-font, var(--font-mono));
+  font-size: var(--active-font-size, 1.05rem);
   line-height: 1.75;
   color: var(--ink-color);
   white-space: pre-wrap;

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
   <title>E-Type — E-Ink Typewriter</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Courier+Prime:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Anonymous+Pro:ital,wght@0,400;0,700;1,400;1,700&family=Courier+Prime:ital,wght@0,400;0,700;1,400;1,700&family=Cutive+Mono&family=Fira+Code:wght@400;700&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Special+Elite&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/index.css">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 </head>
@@ -142,9 +142,23 @@
         </select>
       </div>
       <div class="form-group">
-        <label>Font & Aesthetic</label>
-        <select id="settings-font-select" disabled>
+        <label for="settings-font-select">Font Family</label>
+        <select id="settings-font-select">
           <option value="courier">Courier Prime (Default Typewriter)</option>
+          <option value="special-elite">Special Elite (Vintage Distressed)</option>
+          <option value="cutive-mono">Cutive Mono (IBM Selectric Style)</option>
+          <option value="anonymous-pro">Anonymous Pro (Clean Monospace)</option>
+          <option value="space-mono">Space Mono (Editorial Monospace)</option>
+          <option value="fira-code">Fira Code (Technical Monospace)</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="settings-fontsize-select">Font Size</label>
+        <select id="settings-fontsize-select">
+          <option value="small">Small (14px)</option>
+          <option value="medium">Medium (17px — Default)</option>
+          <option value="large">Large (20px)</option>
+          <option value="xlarge">Extra Large (24px)</option>
         </select>
       </div>
       <div class="form-group">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -49,6 +49,8 @@ function init() {
   const settingsEnableTimestampInputEl = document.getElementById('settings-enable-timestamp');
   const settingsTimestampFormatSelectEl = document.getElementById('settings-timestamp-format');
   const settingsTimestampPositionSelectEl = document.getElementById('settings-timestamp-position');
+  const settingsFontSelectEl = document.getElementById('settings-font-select');
+  const settingsFontsizeSelectEl = document.getElementById('settings-fontsize-select');
   const cancelSettingsBtnEl = document.getElementById('btn-cancel-settings');
   const saveSettingsBtnEl = document.getElementById('btn-save-settings');
 
@@ -86,14 +88,17 @@ function init() {
     settingsEnableTimestampInput: settingsEnableTimestampInputEl,
     settingsTimestampFormatSelect: settingsTimestampFormatSelectEl,
     settingsTimestampPositionSelect: settingsTimestampPositionSelectEl,
+    settingsFontSelect: settingsFontSelectEl,
+    settingsFontsizeSelect: settingsFontsizeSelectEl,
     cancelSettingsBtn: cancelSettingsBtnEl,
     saveSettingsBtn: saveSettingsBtnEl,
     toast: toastEl,
     toastMessage: toastMessageEl,
   });
 
-  // Apply initial word count visibility setting
+  // Apply initial word count visibility and font settings
   ui.setWordCountVisibility(appSettings.showWordCount !== false);
+  ui.applyFontSettings(appSettings.font, appSettings.fontSize);
   
   // ---- Distraction-Free Controls & Bottom Bar Visibility ----
   let mouseIdleTimer = null;
@@ -212,6 +217,7 @@ function init() {
         appSettings = newSettings;
         Storage.saveSettings(newSettings);
         ui.setWordCountVisibility(appSettings.showWordCount !== false);
+        ui.applyFontSettings(appSettings.font, appSettings.fontSize);
         ui.showToast(`Settings saved.`);
       });
     },

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -63,6 +63,8 @@ export function loadSettings() {
         enableTimestamp: true,
         timestampFormat: 'YYYY-MM-DD HH-mm',
         timestampPosition: 'after',
+        font: 'courier',
+        fontSize: 'medium',
       };
     }
     const parsed = JSON.parse(raw);
@@ -72,6 +74,8 @@ export function loadSettings() {
       enableTimestamp: parsed.enableTimestamp !== false,
       timestampFormat: parsed.timestampFormat || 'YYYY-MM-DD HH-mm',
       timestampPosition: parsed.timestampPosition || 'after',
+      font: parsed.font || 'courier',
+      fontSize: parsed.fontSize || 'medium',
     };
   } catch (e) {
     return {
@@ -80,6 +84,8 @@ export function loadSettings() {
       enableTimestamp: true,
       timestampFormat: 'YYYY-MM-DD HH-mm',
       timestampPosition: 'after',
+      font: 'courier',
+      fontSize: 'medium',
     };
   }
 }

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -40,6 +40,8 @@ export class UI {
     this.settingsEnableTimestampInput = elements.settingsEnableTimestampInput;
     this.settingsTimestampFormatSelect = elements.settingsTimestampFormatSelect;
     this.settingsTimestampPositionSelect = elements.settingsTimestampPositionSelect;
+    this.settingsFontSelect = elements.settingsFontSelect;
+    this.settingsFontsizeSelect = elements.settingsFontsizeSelect;
     this.cancelSettingsBtn = elements.cancelSettingsBtn;
     this.saveSettingsBtn = elements.saveSettingsBtn;
     this.toast = elements.toast;
@@ -177,7 +179,7 @@ export class UI {
 
   /**
    * Show the Settings modal dialog.
-   * @param {Object} currentSettings - { driveFolder, showWordCount, enableTimestamp, timestampFormat, timestampPosition }
+   * @param {Object} currentSettings - { driveFolder, showWordCount, enableTimestamp, timestampFormat, timestampPosition, font, fontSize }
    * @param {Function} onSave - Called with (newSettings)
    */
   showSettingsDialog(currentSettings, onSave) {
@@ -198,7 +200,45 @@ export class UI {
     if (this.settingsTimestampPositionSelect) {
       this.settingsTimestampPositionSelect.value = currentSettings.timestampPosition || 'after';
     }
+    if (this.settingsFontSelect) {
+      this.settingsFontSelect.value = currentSettings.font || 'courier';
+    }
+    if (this.settingsFontsizeSelect) {
+      this.settingsFontsizeSelect.value = currentSettings.fontSize || 'medium';
+    }
     this.settingsDialog.showModal();
+  }
+
+  /**
+   * Apply font family and font size to text display.
+   * @param {string} [fontKey='courier']
+   * @param {string} [fontSizeKey='medium']
+   */
+  applyFontSettings(fontKey = 'courier', fontSizeKey = 'medium') {
+    const display = document.getElementById('text-display');
+    if (!display) return;
+
+    const fontFamilies = {
+      'courier': "'Courier Prime', 'Courier New', Courier, monospace",
+      'special-elite': "'Special Elite', 'Courier New', Courier, monospace",
+      'cutive-mono': "'Cutive Mono', 'Courier New', Courier, monospace",
+      'anonymous-pro': "'Anonymous Pro', monospace",
+      'space-mono': "'Space Mono', monospace",
+      'fira-code': "'Fira Code', monospace",
+    };
+
+    const fontSizes = {
+      'small': '0.9rem',
+      'medium': '1.05rem',
+      'large': '1.25rem',
+      'xlarge': '1.5rem',
+    };
+
+    const family = fontFamilies[fontKey] || fontFamilies['courier'];
+    const size = fontSizes[fontSizeKey] || fontSizes['medium'];
+
+    display.style.setProperty('--active-font', family);
+    display.style.setProperty('--active-font-size', size);
   }
 
   /**
@@ -287,6 +327,8 @@ export class UI {
         const enableTimestamp = this.settingsEnableTimestampInput ? this.settingsEnableTimestampInput.checked : true;
         const timestampFormat = this.settingsTimestampFormatSelect ? this.settingsTimestampFormatSelect.value : 'YYYY-MM-DD HH-mm';
         const timestampPosition = this.settingsTimestampPositionSelect ? this.settingsTimestampPositionSelect.value : 'after';
+        const font = this.settingsFontSelect ? this.settingsFontSelect.value : 'courier';
+        const fontSize = this.settingsFontsizeSelect ? this.settingsFontsizeSelect.value : 'medium';
 
         const cb = this._onSaveSettingsConfirm;
         this._onSaveSettingsConfirm = null;
@@ -298,6 +340,8 @@ export class UI {
             enableTimestamp,
             timestampFormat,
             timestampPosition,
+            font,
+            fontSize,
           });
         }
       });


### PR DESCRIPTION
Closes #31

## Summary
- **Font Family Options**: Enabled Font Family dropdown in Settings (`⚙`):
  - Courier Prime (Default Typewriter)
  - Special Elite (Vintage Distressed)
  - Cutive Mono (IBM Selectric Style)
  - Anonymous Pro (Clean Monospace)
  - Space Mono (Editorial Monospace)
  - Fira Code (Technical Monospace)
- **Font Size Options**: Added Font Size dropdown in Settings (`⚙`):
  - Small (`14px`)
  - Medium (`17px` — Default)
  - Large (`20px`)
  - Extra Large (`24px`)
- **Persistence**: Persists font family and size preferences in `localStorage` for all users across browser sessions, applying changes in real-time.