### PR TITLE
feat: Add preset themes, Custom color pickers, and contrast safety (#33)

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -480,14 +480,14 @@ body.show-controls .floating-controls {
 
 .btn-icon {
   background: var(--surface-bg);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 50%;
   width: 44px;
   height: 44px;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--paper-bg);
+  color: var(--icon-color, var(--paper-bg));
   cursor: pointer;
   transition: all 0.2s ease;
   padding: 0;
@@ -495,9 +495,10 @@ body.show-controls .floating-controls {
 }
 
 .btn-icon:hover {
-  background: #2b2b2b;
-  color: #ffffff;
-  border-color: rgba(255, 255, 255, 0.35);
+  background: var(--surface-bg);
+  filter: brightness(1.2);
+  color: var(--icon-color, #ffffff);
+  border-color: rgba(255, 255, 255, 0.4);
   transform: scale(1.1);
 }
 
@@ -532,7 +533,7 @@ body.show-controls .floating-controls {
   font-size: 0.85rem;
   background: rgba(0, 0, 0, 0.04);
   color: var(--toolbar-text);
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .field-help {
@@ -592,6 +593,55 @@ body.show-controls .floating-controls {
 
 #word-count.hidden {
   display: none !important;
+}
+
+.custom-color-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin: 12px 0 16px 0;
+  padding: 12px;
+  background: rgba(0,0,0,0.03);
+  border-radius: 8px;
+  border: 1px solid rgba(0,0,0,0.08);
+}
+
+.custom-color-grid.hidden {
+  display: none !important;
+}
+
+.form-group-color {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.form-group-color label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--toolbar-text);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.form-group-color input[type="color"] {
+  -webkit-appearance: none;
+  border: 1px solid rgba(0,0,0,0.15);
+  border-radius: 6px;
+  width: 100%;
+  height: 36px;
+  cursor: pointer;
+  background: transparent;
+  padding: 2px;
+}
+
+.form-group-color input[type="color"]::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.form-group-color input[type="color"]::-webkit-color-swatch {
+  border: none;
+  border-radius: 4px;
 }
 
 @media (max-width: 640px) {

--- a/public/index.html
+++ b/public/index.html
@@ -162,10 +162,32 @@
         </select>
       </div>
       <div class="form-group">
-        <label>Theme</label>
-        <select id="settings-theme-select" disabled>
+        <label for="settings-theme-select">Theme</label>
+        <select id="settings-theme-select">
           <option value="warm-cream">Warm Cream E-Paper (Default)</option>
+          <option value="dark-mode">Dark Mode E-Paper</option>
+          <option value="sepia">Sepia Nostalgia</option>
+          <option value="high-contrast">High Contrast E-Ink</option>
+          <option value="custom">Custom ("Choose Your Own")</option>
         </select>
+      </div>
+      <div id="custom-color-container" class="custom-color-grid hidden">
+        <div class="form-group-color">
+          <label for="settings-color-surface">Background</label>
+          <input type="color" id="settings-color-surface" value="#1a1a1a">
+        </div>
+        <div class="form-group-color">
+          <label for="settings-color-bezel">Frame / Bezel</label>
+          <input type="color" id="settings-color-bezel" value="#d4cfc7">
+        </div>
+        <div class="form-group-color">
+          <label for="settings-color-paper">Screen Paper</label>
+          <input type="color" id="settings-color-paper" value="#f5f0e8">
+        </div>
+        <div class="form-group-color">
+          <label for="settings-color-ink">Ink / Text</label>
+          <input type="color" id="settings-color-ink" value="#2a2a2a">
+        </div>
       </div>
       <div class="dialog-footer-links">
         <a href="mailto:graham.stalker@gmail.com?subject=E-Type%20Feedback" target="_blank" rel="noopener">Contact Developer / Send Feedback ✉</a>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -51,6 +51,12 @@ function init() {
   const settingsTimestampPositionSelectEl = document.getElementById('settings-timestamp-position');
   const settingsFontSelectEl = document.getElementById('settings-font-select');
   const settingsFontsizeSelectEl = document.getElementById('settings-fontsize-select');
+  const settingsThemeSelectEl = document.getElementById('settings-theme-select');
+  const customColorContainerEl = document.getElementById('custom-color-container');
+  const colorSurfaceInputEl = document.getElementById('settings-color-surface');
+  const colorBezelInputEl = document.getElementById('settings-color-bezel');
+  const colorPaperInputEl = document.getElementById('settings-color-paper');
+  const colorInkInputEl = document.getElementById('settings-color-ink');
   const cancelSettingsBtnEl = document.getElementById('btn-cancel-settings');
   const saveSettingsBtnEl = document.getElementById('btn-save-settings');
 
@@ -90,15 +96,22 @@ function init() {
     settingsTimestampPositionSelect: settingsTimestampPositionSelectEl,
     settingsFontSelect: settingsFontSelectEl,
     settingsFontsizeSelect: settingsFontsizeSelectEl,
+    settingsThemeSelect: settingsThemeSelectEl,
+    customColorContainer: customColorContainerEl,
+    colorSurfaceInput: colorSurfaceInputEl,
+    colorBezelInput: colorBezelInputEl,
+    colorPaperInput: colorPaperInputEl,
+    colorInkInput: colorInkInputEl,
     cancelSettingsBtn: cancelSettingsBtnEl,
     saveSettingsBtn: saveSettingsBtnEl,
     toast: toastEl,
     toastMessage: toastMessageEl,
   });
 
-  // Apply initial word count visibility and font settings
+  // Apply initial word count visibility, font, and theme settings
   ui.setWordCountVisibility(appSettings.showWordCount !== false);
   ui.applyFontSettings(appSettings.font, appSettings.fontSize);
+  ui.applyThemeSettings(appSettings.theme, appSettings.customColors);
   
   // ---- Distraction-Free Controls & Bottom Bar Visibility ----
   let mouseIdleTimer = null;
@@ -218,6 +231,7 @@ function init() {
         Storage.saveSettings(newSettings);
         ui.setWordCountVisibility(appSettings.showWordCount !== false);
         ui.applyFontSettings(appSettings.font, appSettings.fontSize);
+        ui.applyThemeSettings(appSettings.theme, appSettings.customColors);
         ui.showToast(`Settings saved.`);
       });
     },

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -54,39 +54,36 @@ export function saveSettings(settings) {
  * @returns {Object} Saved settings or defaults.
  */
 export function loadSettings() {
+  const defaults = {
+    driveFolder: 'etype_drafts',
+    showWordCount: true,
+    enableTimestamp: true,
+    timestampFormat: 'YYYY-MM-DD HH-mm',
+    timestampPosition: 'after',
+    font: 'courier',
+    fontSize: 'medium',
+    theme: 'warm-cream',
+    customColors: {
+      surface: '#1a1a1a',
+      bezel: '#d4cfc7',
+      paper: '#f5f0e8',
+      ink: '#2a2a2a',
+    },
+  };
   try {
     const raw = localStorage.getItem(SETTINGS_KEY);
-    if (!raw) {
-      return {
-        driveFolder: 'etype_drafts',
-        showWordCount: true,
-        enableTimestamp: true,
-        timestampFormat: 'YYYY-MM-DD HH-mm',
-        timestampPosition: 'after',
-        font: 'courier',
-        fontSize: 'medium',
-      };
-    }
+    if (!raw) return defaults;
     const parsed = JSON.parse(raw);
     return {
-      driveFolder: parsed.driveFolder || 'etype_drafts',
-      showWordCount: parsed.showWordCount !== false,
-      enableTimestamp: parsed.enableTimestamp !== false,
-      timestampFormat: parsed.timestampFormat || 'YYYY-MM-DD HH-mm',
-      timestampPosition: parsed.timestampPosition || 'after',
-      font: parsed.font || 'courier',
-      fontSize: parsed.fontSize || 'medium',
+      ...defaults,
+      ...parsed,
+      customColors: {
+        ...defaults.customColors,
+        ...(parsed.customColors || {}),
+      },
     };
   } catch (e) {
-    return {
-      driveFolder: 'etype_drafts',
-      showWordCount: true,
-      enableTimestamp: true,
-      timestampFormat: 'YYYY-MM-DD HH-mm',
-      timestampPosition: 'after',
-      font: 'courier',
-      fontSize: 'medium',
-    };
+    return defaults;
   }
 }
 

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -42,6 +42,12 @@ export class UI {
     this.settingsTimestampPositionSelect = elements.settingsTimestampPositionSelect;
     this.settingsFontSelect = elements.settingsFontSelect;
     this.settingsFontsizeSelect = elements.settingsFontsizeSelect;
+    this.settingsThemeSelect = elements.settingsThemeSelect;
+    this.customColorContainer = elements.customColorContainer;
+    this.colorSurfaceInput = elements.colorSurfaceInput;
+    this.colorBezelInput = elements.colorBezelInput;
+    this.colorPaperInput = elements.colorPaperInput;
+    this.colorInkInput = elements.colorInkInput;
     this.cancelSettingsBtn = elements.cancelSettingsBtn;
     this.saveSettingsBtn = elements.saveSettingsBtn;
     this.toast = elements.toast;
@@ -179,7 +185,7 @@ export class UI {
 
   /**
    * Show the Settings modal dialog.
-   * @param {Object} currentSettings - { driveFolder, showWordCount, enableTimestamp, timestampFormat, timestampPosition, font, fontSize }
+   * @param {Object} currentSettings - App settings
    * @param {Function} onSave - Called with (newSettings)
    */
   showSettingsDialog(currentSettings, onSave) {
@@ -206,7 +212,111 @@ export class UI {
     if (this.settingsFontsizeSelect) {
       this.settingsFontsizeSelect.value = currentSettings.fontSize || 'medium';
     }
+    if (this.settingsThemeSelect) {
+      this.settingsThemeSelect.value = currentSettings.theme || 'warm-cream';
+    }
+
+    const customColors = currentSettings.customColors || {};
+    if (this.colorSurfaceInput) this.colorSurfaceInput.value = customColors.surface || '#1a1a1a';
+    if (this.colorBezelInput) this.colorBezelInput.value = customColors.bezel || '#d4cfc7';
+    if (this.colorPaperInput) this.colorPaperInput.value = customColors.paper || '#f5f0e8';
+    if (this.colorInkInput) this.colorInkInput.value = customColors.ink || '#2a2a2a';
+
+    this._updateCustomColorVisibility(this.settingsThemeSelect ? this.settingsThemeSelect.value : 'warm-cream');
+
     this.settingsDialog.showModal();
+  }
+
+  /**
+   * Toggle visibility of custom color pickers based on theme selection.
+   * @param {string} themeKey
+   */
+  _updateCustomColorVisibility(themeKey) {
+    if (!this.customColorContainer) return;
+    if (themeKey === 'custom') {
+      this.customColorContainer.classList.remove('hidden');
+    } else {
+      this.customColorContainer.classList.add('hidden');
+    }
+  }
+
+  /**
+   * Calculates luminance of a hex color string and returns a contrasting text/icon color.
+   * @param {string} hex
+   * @returns {string} High-contrast color hex/rgba
+   */
+  _getContrastingColor(hex) {
+    if (!hex || typeof hex !== 'string') return 'rgba(0, 0, 0, 0.75)';
+    let c = hex.replace('#', '').trim();
+    if (c.length === 3) {
+      c = c.split('').map(x => x + x).join('');
+    }
+    if (c.length !== 6) return 'rgba(0, 0, 0, 0.75)';
+
+    const r = parseInt(c.substring(0, 2), 16);
+    const g = parseInt(c.substring(2, 4), 16);
+    const b = parseInt(c.substring(4, 6), 16);
+
+    const luminance = (r * 299 + g * 587 + b * 114) / 1000;
+    return luminance < 140 ? 'rgba(255, 255, 255, 0.88)' : 'rgba(0, 0, 0, 0.75)';
+  }
+
+  /**
+   * Apply preset theme or custom colors to the root document with contrast safety.
+   * @param {string} [themeKey='warm-cream']
+   * @param {Object} [customColors]
+   */
+  applyThemeSettings(themeKey = 'warm-cream', customColors = {}) {
+    const root = document.documentElement;
+
+    const presetPalettes = {
+      'warm-cream': {
+        surface: '#1a1a1a',
+        bezel: '#d4cfc7',
+        paper: '#f5f0e8',
+        ink: '#2a2a2a',
+      },
+      'dark-mode': {
+        surface: '#121212',
+        bezel: '#282b2e',
+        paper: '#1e2022',
+        ink: '#e2e2e2',
+      },
+      'sepia': {
+        surface: '#282019',
+        bezel: '#ded3c4',
+        paper: '#f4ecd8',
+        ink: '#3c2f23',
+      },
+      'high-contrast': {
+        surface: '#000000',
+        bezel: '#d0d0d0',
+        paper: '#ffffff',
+        ink: '#000000',
+      },
+    };
+
+    let palette = presetPalettes[themeKey];
+    if (themeKey === 'custom' || !palette) {
+      palette = {
+        surface: customColors.surface || '#1a1a1a',
+        bezel: customColors.bezel || '#d4cfc7',
+        paper: customColors.paper || '#f5f0e8',
+        ink: customColors.ink || '#2a2a2a',
+      };
+    }
+
+    const iconColor = this._getContrastingColor(palette.surface);
+    const toolbarTextColor = this._getContrastingColor(palette.bezel);
+
+    root.style.setProperty('--surface-bg', palette.surface);
+    root.style.setProperty('--device-bezel', palette.bezel);
+    root.style.setProperty('--device-bezel-dark', palette.bezel);
+    root.style.setProperty('--paper-bg', palette.paper);
+    root.style.setProperty('--ink-color', palette.ink);
+    root.style.setProperty('--cursor-color', palette.ink);
+    root.style.setProperty('--icon-color', iconColor);
+    root.style.setProperty('--toolbar-text', toolbarTextColor);
   }
 
   /**
@@ -309,6 +419,13 @@ export class UI {
       });
     }
 
+    // Toggle custom color pickers visibility when theme select changes
+    if (this.settingsThemeSelect) {
+      this.settingsThemeSelect.addEventListener('change', (e) => {
+        this._updateCustomColorVisibility(e.target.value);
+      });
+    }
+
     // Close Info dialog
     if (this.closeInfoBtn && this.infoDialog) {
       this.closeInfoBtn.addEventListener('click', () => {
@@ -329,6 +446,13 @@ export class UI {
         const timestampPosition = this.settingsTimestampPositionSelect ? this.settingsTimestampPositionSelect.value : 'after';
         const font = this.settingsFontSelect ? this.settingsFontSelect.value : 'courier';
         const fontSize = this.settingsFontsizeSelect ? this.settingsFontsizeSelect.value : 'medium';
+        const theme = this.settingsThemeSelect ? this.settingsThemeSelect.value : 'warm-cream';
+        const customColors = {
+          surface: this.colorSurfaceInput ? this.colorSurfaceInput.value : '#1a1a1a',
+          bezel: this.colorBezelInput ? this.colorBezelInput.value : '#d4cfc7',
+          paper: this.colorPaperInput ? this.colorPaperInput.value : '#f5f0e8',
+          ink: this.colorInkInput ? this.colorInkInput.value : '#2a2a2a',
+        };
 
         const cb = this._onSaveSettingsConfirm;
         this._onSaveSettingsConfirm = null;
@@ -342,6 +466,8 @@ export class UI {
             timestampPosition,
             font,
             fontSize,
+            theme,
+            customColors,
           });
         }
       });


### PR DESCRIPTION
Closes #33

## Summary
- **Calm Preset Themes**: Added 4 soothing distraction-free preset themes:
  - **Warm Cream E-Paper** (Default)
  - **Dark Mode E-Paper** (Kindle Dark)
  - **Sepia Nostalgia** (Aged Book Parchment)
  - **High Contrast E-Ink** (Pure Black & White)
- **Custom Color Picker ("Choose Your Own")**:
  - Selecting **Custom** opens 4 color pickers to customize **Outer Background**, **Device Frame/Bezel**, **Screen Paper**, and **Ink/Text**.
- **Automatic Contrast & Legibility Safety**:
  - Automatically calculates luminance for the outer background and device frame to ensure top Info/Settings icons and bottom bezel text/controls remain 100% legible and visible regardless of color choices.