### PR TITLE
feat: Add vertical grey bezel slider to control typing window height (#39)

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -68,12 +68,83 @@ body {
 #etype-screen {
   background-color: var(--paper-bg);
   border-radius: 4px;
-  height: var(--screen-height);
+  height: var(--active-screen-height, var(--screen-height));
+  max-height: var(--screen-height);
   overflow-y: auto;
   overflow-x: hidden;
   box-shadow: inset 0 2px 8px rgba(0,0,0,0.06), inset 0 0 0 1px rgba(0,0,0,0.04);
   position: relative;
   flex-shrink: 0;
+  transition: height 0.2s ease-out;
+}
+
+.bezel-slider-container {
+  position: absolute;
+  right: 1px;
+  top: 12px;
+  height: var(--screen-height);
+  width: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+  transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1), visibility 0.4s ease;
+}
+
+body.show-controls .bezel-slider-container,
+.bezel-slider-container:focus-within,
+.bezel-slider-container:hover {
+  opacity: 0.85;
+  pointer-events: auto;
+  visibility: visible;
+}
+
+#height-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: calc(var(--screen-height) - 24px);
+  height: 4px;
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 2px;
+  outline: none;
+  transform: rotate(-90deg);
+  transform-origin: center center;
+  cursor: ns-resize;
+  transition: background 0.2s ease;
+}
+
+#height-slider:hover {
+  background: rgba(0, 0, 0, 0.3);
+}
+
+#height-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--toolbar-text, #4a4a4a);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+  cursor: ns-resize;
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+
+#height-slider::-webkit-slider-thumb:hover {
+  transform: scale(1.3);
+  background: var(--ink-color, #1a1a1a);
+}
+
+#height-slider::-moz-range-thumb {
+  width: 10px;
+  height: 10px;
+  border: none;
+  border-radius: 50%;
+  background: var(--toolbar-text, #4a4a4a);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+  cursor: ns-resize;
 }
 
 #device-footer {

--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,9 @@
       <div id="etype-screen">
         <div id="text-display"><span id="cursor" class="cursor">█</span></div>
       </div>
+      <div class="bezel-slider-container" title="Adjust typing window height">
+        <input type="range" id="height-slider" min="15" max="100" value="100" aria-label="Adjust typing window height">
+      </div>
       <footer id="device-footer">
         <div class="status-bar">
           <span id="word-count" aria-live="polite">0 words</span>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -57,6 +57,7 @@ function init() {
   const colorBezelInputEl = document.getElementById('settings-color-bezel');
   const colorPaperInputEl = document.getElementById('settings-color-paper');
   const colorInkInputEl = document.getElementById('settings-color-ink');
+  const heightSliderEl = document.getElementById('height-slider');
   const cancelSettingsBtnEl = document.getElementById('btn-cancel-settings');
   const saveSettingsBtnEl = document.getElementById('btn-save-settings');
 
@@ -102,16 +103,18 @@ function init() {
     colorBezelInput: colorBezelInputEl,
     colorPaperInput: colorPaperInputEl,
     colorInkInput: colorInkInputEl,
+    heightSlider: heightSliderEl,
     cancelSettingsBtn: cancelSettingsBtnEl,
     saveSettingsBtn: saveSettingsBtnEl,
     toast: toastEl,
     toastMessage: toastMessageEl,
   });
 
-  // Apply initial word count visibility, font, and theme settings
+  // Apply initial word count visibility, font, theme, and viewport height settings
   ui.setWordCountVisibility(appSettings.showWordCount !== false);
   ui.applyFontSettings(appSettings.font, appSettings.fontSize);
   ui.applyThemeSettings(appSettings.theme, appSettings.customColors);
+  ui.applyViewportHeight(appSettings.viewportHeight || 100);
   
   // ---- Distraction-Free Controls & Bottom Bar Visibility ----
   let mouseIdleTimer = null;
@@ -234,6 +237,11 @@ function init() {
         ui.applyThemeSettings(appSettings.theme, appSettings.customColors);
         ui.showToast(`Settings saved.`);
       });
+    },
+
+    onViewportHeightChange: (val) => {
+      appSettings.viewportHeight = val;
+      Storage.saveSettings(appSettings);
     },
 
     onGDrive: async () => {

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -63,6 +63,7 @@ export function loadSettings() {
     font: 'courier',
     fontSize: 'medium',
     theme: 'warm-cream',
+    viewportHeight: 100,
     customColors: {
       surface: '#1a1a1a',
       bezel: '#d4cfc7',

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -48,6 +48,7 @@ export class UI {
     this.colorBezelInput = elements.colorBezelInput;
     this.colorPaperInput = elements.colorPaperInput;
     this.colorInkInput = elements.colorInkInput;
+    this.heightSlider = elements.heightSlider;
     this.cancelSettingsBtn = elements.cancelSettingsBtn;
     this.saveSettingsBtn = elements.saveSettingsBtn;
     this.toast = elements.toast;
@@ -352,6 +353,21 @@ export class UI {
   }
 
   /**
+   * Apply typing viewport height percentage (15% to 100%).
+   * @param {number} percentage - 15 to 100
+   */
+  applyViewportHeight(percentage = 100) {
+    const pct = Math.max(15, Math.min(100, Number(percentage) || 100));
+    if (this.screen) {
+      this.screen.style.setProperty('--active-screen-height', `calc(var(--screen-height) * ${pct / 100})`);
+      this.scrollToBottom();
+    }
+    if (this.heightSlider) {
+      this.heightSlider.value = String(pct);
+    }
+  }
+
+  /**
    * Toggle visibility of the word count in the status bar.
    * @param {boolean} visible
    */
@@ -423,6 +439,17 @@ export class UI {
     if (this.settingsThemeSelect) {
       this.settingsThemeSelect.addEventListener('change', (e) => {
         this._updateCustomColorVisibility(e.target.value);
+      });
+    }
+
+    // Bezel viewport height slider
+    if (this.heightSlider) {
+      this.heightSlider.addEventListener('input', (e) => {
+        const val = Number(e.target.value) || 100;
+        this.applyViewportHeight(val);
+        if (handlers.onViewportHeightChange) {
+          handlers.onViewportHeightChange(val);
+        }
       });
     }
 


### PR DESCRIPTION
Closes #39

## Summary
- **Restricted Viewport Height (Line Focus Mode)**: Added a vertical range slider control to the right margin of the grey device bezel (`#screen-container`).
- **Subtle Grey Bezel Aesthetics**: Styled with a clean, subtle grey track and thumb (`var(--toolbar-text)`) matching the e-ink bezel frame.
- **Visibility & Motion Sync**: Fades in only on mouse hover / mouseover of the typing area (synchronized with the bottom toolbar and auth controls).
- **Smooth Viewport Height Control**: Dynamically resizes the e-paper viewport (`#etype-screen`) from 15% (single line focus) up to 100% (full page).
- **Bezel Containment**: The slider remains fully contained within the bezel frame boundaries.
- **Persistence**: Persists user's chosen viewport height in `localStorage`.